### PR TITLE
feat!(api): hide finite and symmetry proofs behind matrix APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,15 +128,14 @@ fn main() -> Result<(), LaError> {
 ```
 
 > ⚠️ **LDLT invariant:** The input matrix must be **symmetric**. Asymmetric
-> inputs return a typed `LaError::Asymmetric` before factorization starts.
-> Use
-> [`SymmetricMatrix`](https://docs.rs/la-stack/latest/la_stack/struct.SymmetricMatrix.html)
-> when you want to validate symmetry once and carry that proof into LDLT. Use
+> inputs passed to
+> [`Matrix::ldlt`](https://docs.rs/la-stack/latest/la_stack/struct.Matrix.html#method.ldlt)
+> return a typed `LaError::Asymmetric` before factorization starts. Use
 > [`Matrix::first_asymmetry`](https://docs.rs/la-stack/latest/la_stack/struct.Matrix.html#method.first_asymmetry)
 > to locate the offending pair, or fall back to `lu()` if your matrices may not
-> be symmetric at all. See
-> [`Matrix::ldlt`](https://docs.rs/la-stack/latest/la_stack/struct.Matrix.html#method.ldlt)
-> for the raw convenience path.
+> be symmetric at all. Symmetric inputs with a negative LDLT diagonal return
+> `LaError::NotPositiveSemidefinite`; zero or too-small non-negative diagonals
+> return `LaError::Singular`.
 
 ## ⚡ Compile-time determinants (D ≤ 4)
 
@@ -261,15 +260,34 @@ fn main() -> Result<(), LaError> {
 }
 ```
 
-The error coefficients (`ERR_COEFF_2`, `ERR_COEFF_3`, `ERR_COEFF_4`) are also
-exposed for advanced use cases.
+The error coefficients (`ERR_COEFF_2`, `ERR_COEFF_3`, `ERR_COEFF_4`) are the
+dimension-specific constants behind that bound. In plain terms, they answer:
+"how many machine-epsilon-sized rounding mistakes can this closed-form
+determinant formula accumulate?" To get an absolute error bound, `det_errbound()`
+multiplies the coefficient by a size measure of the matrix entries, the
+**absolute Leibniz sum**:
+
+```text
+p(|A|) = sum over determinant terms of product of absolute values
+```
+
+For a 2×2 matrix `[[a, b], [c, d]]`, that scale is `|a*d| + |b*c|`, so:
+
+```text
+|det_direct(A) - det_exact(A)| <= ERR_COEFF_2 * (|a*d| + |b*c|)
+```
+
+The coefficients are not tolerances and are not meant to be tuned by callers;
+they are conservative constants derived from the fixed D ≤ 4 formulas and their
+floating-point rounding chains. They are exposed for advanced users who want to
+compose the same bound themselves.
 
 ## 🧩 API at a glance
 
 | Type | Storage | Purpose | Key methods |
 |---|---|---|---|
-| `Vector<D>` | `[f64; D]` | Fixed-length vector | `new`, `zero`, `dot`, `norm2_sq` |
-| `Matrix<D>` | `[[f64; D]; D]` | Square matrix | See below |
+| `Vector<D>` | `[f64; D]` | Fixed-length vector for input and computation | `new`, `zero`, `dot`, `norm2_sq` |
+| `Matrix<D>` | `[[f64; D]; D]` | Square matrix for input and computation | See below |
 | `Lu<D>` | `Matrix<D>` + pivot array | Factorization for solves/det | `solve_vec`, `det` |
 | `Ldlt<D>` | `Matrix<D>` | Factorization for symmetric SPD/PSD solves/det | `solve_vec`, `det` |
 
@@ -277,6 +295,9 @@ Storage shown above reflects the intentional `f64` scalar model.
 
 `Matrix<D>` key methods: `lu`, `ldlt`, `det`, `det_direct`, `det_errbound`,
 `det_exact`¹, `det_exact_f64`¹, `det_sign_exact`¹, `solve_exact`¹, `solve_exact_f64`¹.
+Matrix and vector methods validate non-finite inputs at public API boundaries and
+carry internal proof types through computation so successful factors do not store
+NaN or infinity.
 
 ¹ Requires `features = ["exact"]`.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -35,28 +35,54 @@ The `v0.4.2` milestone collects the work that can be done on today's stable
 Rust while keeping the crate useful to downstream geometry crates. The GitHub
 native Blocking / Is blocked by graph mirrors this order:
 
-- [#100](https://github.com/acgetchell/la-stack/issues/100) - Clarify `f64`
+Completed foundation work:
+
+- [#100](https://github.com/acgetchell/la-stack/issues/100) clarified `f64`
   as the intended floating-point type in README and other documentation.
-- [#109](https://github.com/acgetchell/la-stack/issues/109) - Add fallible
+- [#109](https://github.com/acgetchell/la-stack/issues/109) added fallible
   runtime matrix dispatch and contextual index errors.
-- [#83](https://github.com/acgetchell/la-stack/issues/83) - Change
+- [#83](https://github.com/acgetchell/la-stack/issues/83) changed
   `Matrix::set` to return `Option<()>` instead of `bool`.
-- [#94](https://github.com/acgetchell/la-stack/issues/94) - Validate
-  tolerance arguments consistently across the crate.
-- [#82](https://github.com/acgetchell/la-stack/issues/82) - Unify `det()`
+- [#94](https://github.com/acgetchell/la-stack/issues/94) made tolerance
+  parsing explicit and consistent across the crate.
+- [#82](https://github.com/acgetchell/la-stack/issues/82) unified `det()`
   error behavior across all dimensions as far as stable Rust allows.
-- [#120](https://github.com/acgetchell/la-stack/issues/120) - Run the
+- [#120](https://github.com/acgetchell/la-stack/issues/120) completed the
   parse-don't-validate `NonZero*` audit.
-- [#126](https://github.com/acgetchell/la-stack/issues/126) - Add finite
-  `Matrix` and `Vector` proof types.
+- [#111](https://github.com/acgetchell/la-stack/issues/111),
+  [#112](https://github.com/acgetchell/la-stack/issues/112),
+  [#113](https://github.com/acgetchell/la-stack/issues/113), and
+  [#117](https://github.com/acgetchell/la-stack/issues/117) cleaned up
+  Markdown/YAML tooling, CI speed, and shared Rust workflow/security checks.
+
+Current API-invariant cleanup:
+
+- [#126](https://github.com/acgetchell/la-stack/issues/126) is resolved as an
+  internal parse-don't-validate design rather than a public proof-type API.
+  `Matrix<D>` and `Vector<D>` remain the raw boundary types so callers can pass
+  deserialized, fixture, or otherwise unchecked `f64` storage and receive
+  structured diagnostics. Crate-private `FiniteMatrix<D>` and
+  `FiniteVector<D>` carry the finite-entry proof behind the scenes for LU,
+  LDLT, determinant, error-bound, and exact-arithmetic paths.
+- The public LDLT API remains `Matrix::ldlt`. Symmetry proof storage is kept
+  internal, `SymmetricMatrix` is not exported, asymmetric inputs return
+  `LaError::Asymmetric`, and negative LDLT pivots return
+  `LaError::NotPositiveSemidefinite` rather than being folded into
+  `LaError::Singular`.
+- The determinant error-bound constants `ERR_COEFF_2`, `ERR_COEFF_3`, and
+  `ERR_COEFF_4` are documented as dimension-specific roundoff multipliers over
+  the absolute Leibniz sum, not caller-tuned tolerances.
+
+Remaining release blockers:
+
 - [#125](https://github.com/acgetchell/la-stack/issues/125) - Add a Semgrep
   guardrail against `unwrap` / `expect` in examples, benches, and doctests.
 - [#98](https://github.com/acgetchell/la-stack/issues/98) - Add random-input
   percentile benchmarks to the exact arithmetic suite.
 
-The broad shape is: document scope first, add downstream dispatch ergonomics,
-clean up small API contracts, tighten validation, make reusable invariants
-explicit in proof-carrying types, lock the public examples and benchmarks into
+The broad shape is now: document scalar scope, add downstream dispatch
+ergonomics, clean up small API contracts, tighten validation, encode reusable
+invariants behind the public raw-boundary API, lock examples and benchmarks into
 proper error handling, then finish with broader benchmark work.
 
 ### v0.5.0 Generic Const Expressions

--- a/src/exact.rs
+++ b/src/exact.rs
@@ -59,14 +59,11 @@
 //!
 //! ## Validation
 //!
-//! `decompose_matrix` / `decompose_vec` fold an `is_finite()` check
-//! into the same pass that decomposes each entry, returning
-//! `Err(LaError::NonFinite { row, col })` on the first NaN or ±∞
-//! encountered.  This error is propagated through `bareiss_det_int`,
-//! `bareiss_det`, and `gauss_solve` via the `?` operator, so every
-//! public entry point that reaches the integer-Bareiss core is
-//! automatically validated — `f64_decompose` itself is therefore
-//! never called with non-finite input from the public API.
+//! Public exact methods parse raw `Matrix` / `Vector` values into internal finite
+//! proof types before reaching the integer-Bareiss core.  The decomposition
+//! helpers for those proof types can then call `f64_decompose` without repeating
+//! stored-entry validation; `f64_decompose` itself is therefore never called with
+//! non-finite input from the public API.
 
 use core::hint::cold_path;
 use core::mem::take;
@@ -78,8 +75,8 @@ use num_rational::BigRational;
 use num_traits::ToPrimitive;
 
 use crate::LaError;
-use crate::matrix::Matrix;
-use crate::vector::Vector;
+use crate::matrix::{FiniteMatrix, Matrix};
+use crate::vector::{FiniteVector, Vector};
 
 /// Decompose a finite `f64` into its IEEE 754 components.
 ///
@@ -165,8 +162,8 @@ fn bigint_exp_to_bigrational(mut value: BigInt, mut exp: i32) -> BigRational {
 /// Decomposed finite f64 in the form `(-1)^is_negative · mantissa · 2^exponent`.
 ///
 /// Zero entries have `mantissa == None`; the other fields are unused in that
-/// case. `Default` yields such a zero component, which is what the
-/// per-entry initialiser in `decompose_matrix` / `decompose_vec` produces
+/// case. `Default` yields such a zero component, which is what the per-entry
+/// initialiser in `decompose_finite_matrix` / `decompose_finite_vec` produces
 /// for ±0.0 cells. Non-zero entries carry a [`NonZeroU64`] mantissa, so the
 /// exact-arithmetic paths cannot accidentally store a raw zero sentinel after
 /// decomposition.
@@ -177,23 +174,16 @@ struct Component {
     is_negative: bool,
 }
 
-/// Decompose every entry of a `D×D` matrix via `f64_decompose`,
-/// validating finiteness in the same pass.  Returns the per-entry
-/// components and the minimum exponent across non-zero entries.  If
-/// every entry is zero, the exponent is `i32::MAX`.
+/// Decompose every entry of a finite `D×D` matrix via `f64_decompose`.
 ///
-/// # Errors
-/// Returns [`LaError::NonFinite`] with `row: Some(r), col: c` pointing
-/// at the first non-finite entry encountered (row-major order).
-fn decompose_matrix<const D: usize>(m: &Matrix<D>) -> Result<([[Component; D]; D], i32), LaError> {
+/// Returns the per-entry components and the minimum exponent across non-zero
+/// entries. If every entry is zero, the exponent is `i32::MAX`.
+fn decompose_finite_matrix<const D: usize>(m: &FiniteMatrix<D>) -> ([[Component; D]; D], i32) {
     let mut components = [[Component::default(); D]; D];
     let mut e_min = i32::MAX;
-    for (r, row) in m.rows.iter().enumerate() {
+    let matrix = m.as_matrix();
+    for (r, row) in matrix.rows.iter().enumerate() {
         for (c, &entry) in row.iter().enumerate() {
-            if !entry.is_finite() {
-                cold_path();
-                return Err(LaError::non_finite_cell(r, c));
-            }
             if let Some((mantissa, exponent, is_negative)) = f64_decompose(entry) {
                 components[r][c] = Component {
                     mantissa: Some(mantissa),
@@ -204,25 +194,18 @@ fn decompose_matrix<const D: usize>(m: &Matrix<D>) -> Result<([[Component; D]; D
             }
         }
     }
-    Ok((components, e_min))
+    (components, e_min)
 }
 
-/// Decompose every entry of a length-`D` vector via `f64_decompose`,
-/// validating finiteness in the same pass.  Returns the per-entry
-/// components and the minimum exponent across non-zero entries.  If
-/// every entry is zero, the exponent is `i32::MAX`.
+/// Decompose every entry of a finite length-`D` vector via `f64_decompose`.
 ///
-/// # Errors
-/// Returns [`LaError::NonFinite`] with `row: None, col: i` pointing at
-/// the first non-finite entry encountered.
-fn decompose_vec<const D: usize>(v: &Vector<D>) -> Result<([Component; D], i32), LaError> {
+/// Returns the per-entry components and the minimum exponent across non-zero
+/// entries. If every entry is zero, the exponent is `i32::MAX`.
+fn decompose_finite_vec<const D: usize>(v: &FiniteVector<D>) -> ([Component; D], i32) {
     let mut components = [Component::default(); D];
     let mut e_min = i32::MAX;
-    for (i, &entry) in v.data.iter().enumerate() {
-        if !entry.is_finite() {
-            cold_path();
-            return Err(LaError::non_finite_at(i));
-        }
+    let data = v.as_array();
+    for (i, &entry) in data.iter().enumerate() {
         if let Some((mantissa, exponent, is_negative)) = f64_decompose(entry) {
             components[i] = Component {
                 mantissa: Some(mantissa),
@@ -232,7 +215,7 @@ fn decompose_vec<const D: usize>(v: &Vector<D>) -> Result<([Component; D], i32),
             e_min = e_min.min(exponent);
         }
     }
-    Ok((components, e_min))
+    (components, e_min)
 }
 
 /// Convert a single decomposed component to its scaled `BigInt`
@@ -358,21 +341,18 @@ fn bareiss_forward_eliminate<const D: usize>(
 /// scaled to a common base `2^e_min` so every entry becomes an integer.
 /// The Bareiss inner-loop division is exact (guaranteed by the algorithm).
 ///
-/// # Errors
-/// Returns [`LaError::NonFinite`] (propagated from `decompose_matrix`) if
-/// any matrix entry is NaN or infinite.
-fn bareiss_det_int<const D: usize>(m: &Matrix<D>) -> Result<(BigInt, i32), LaError> {
+fn bareiss_det_int_finite<const D: usize>(m: &FiniteMatrix<D>) -> (BigInt, i32) {
     // D == 0 has no `a[D-1][D-1]` to read; shortcut to the empty-product
     // determinant.
     if D == 0 {
-        return Ok((BigInt::from(1), 0));
+        return (BigInt::from(1), 0);
     }
 
-    let (components, e_min) = decompose_matrix(m)?;
+    let (components, e_min) = decompose_finite_matrix(m);
 
     // All entries are zero → singular (det = 0).
     if e_min == i32::MAX {
-        return Ok((BigInt::from(0), 0));
+        return (BigInt::from(0), 0);
     }
 
     let mut a = build_bigint_matrix(&components, e_min);
@@ -380,7 +360,7 @@ fn bareiss_det_int<const D: usize>(m: &Matrix<D>) -> Result<(BigInt, i32), LaErr
         BareissResult::Upper { sign } => sign,
         BareissResult::Singular { .. } => {
             cold_path();
-            return Ok((BigInt::from(0), 0));
+            return (BigInt::from(0), 0);
         }
     };
 
@@ -396,55 +376,49 @@ fn bareiss_det_int<const D: usize>(m: &Matrix<D>) -> Result<(BigInt, i32), LaErr
         .checked_mul(d_i32)
         .expect("exponent overflow in bareiss_det_int");
 
-    Ok((det_int, total_exp))
+    (det_int, total_exp)
 }
 
 /// Compute the exact determinant of a `D×D` matrix using integer-only Bareiss
 /// elimination and return the result as a `BigRational`.
-///
-/// # Errors
-/// Returns [`LaError::NonFinite`] if any matrix entry is NaN or infinite.
-fn bareiss_det<const D: usize>(m: &Matrix<D>) -> Result<BigRational, LaError> {
-    let (det_int, total_exp) = bareiss_det_int(m)?;
-    Ok(bigint_exp_to_bigrational(det_int, total_exp))
+fn bareiss_det_finite<const D: usize>(m: &FiniteMatrix<D>) -> BigRational {
+    let (det_int, total_exp) = bareiss_det_int_finite(m);
+    bigint_exp_to_bigrational(det_int, total_exp)
 }
 
-/// Solve `A x = b` using a hybrid BigInt/BigRational algorithm.
+/// Solve `A x = b` exactly after matrix and RHS finiteness has been proven.
 ///
-/// Forward elimination runs entirely in `BigInt` using fraction-free
-/// Bareiss updates on the augmented system `(A | b)`: every f64 entry
-/// is decomposed into `mantissa × 2^exponent` and scaled to a shared
-/// base `2^e_min` so both the matrix and the RHS become integer.
-/// Because the same power-of-two scaling is applied to both sides of
-/// `A x = b`, the solution is unchanged.  Row swaps also swap the RHS
-/// row; no sign tracking is needed (pivot permutations do not affect
-/// the solution of a linear system).
-///
-/// After forward elimination, the upper-triangular `BigInt` system and
-/// its RHS are lifted into `BigRational` for back-substitution, where
-/// fractions are inherent.  This keeps the expensive `O(D³)` phase
-/// GCD-free and limits `BigRational` work to the cheaper `O(D²)` phase.
-///
-/// Returns the exact solution as `[BigRational; D]`.
+/// Public solve APIs parse raw [`Matrix`] / [`Vector`] values before reaching
+/// this helper, so decomposition can proceed without rediscovering stored
+/// NaN/∞ entries.
 ///
 /// # Errors
-/// Returns [`LaError::NonFinite`] (propagated from `decompose_matrix` /
-/// `decompose_vec`) if any matrix or vector entry is NaN or infinite.
-/// The matrix is validated before the vector, matching public-API order.
 /// Returns [`LaError::Singular`] if the matrix is exactly singular.
-fn gauss_solve<const D: usize>(m: &Matrix<D>, b: &Vector<D>) -> Result<[BigRational; D], LaError> {
-    // Decompose both matrix and RHS (validating finiteness in one pass);
-    // the shared minimum exponent makes every entry of the augmented
-    // system an integer after scaling.
-    let (m_components, m_e_min) = decompose_matrix(m)?;
-    let (b_components, b_e_min) = decompose_vec(b)?;
-    let mut e_min = m_e_min.min(b_e_min);
+fn gauss_solve_finite<const D: usize>(
+    m: &FiniteMatrix<D>,
+    b: &FiniteVector<D>,
+) -> Result<[BigRational; D], LaError> {
+    let (m_components, m_e_min) = decompose_finite_matrix(m);
+    let (b_components, b_e_min) = decompose_finite_vec(b);
+    gauss_solve_components(m_components, m_e_min, b_components, b_e_min)
+}
 
-    // All matrix + RHS entries are zero.  For `D > 0` this surfaces as
-    // singular inside forward elimination; for `D == 0` the elimination
-    // loop body is empty and we return `Ok([])` without touching e_min.
-    // Pick any finite value so the shift computation is well-defined (the
-    // resulting BigInts are all zero either way).
+/// Solve an exact integer-scaled augmented system from decomposed components.
+///
+/// Forward elimination runs in [`BigInt`] using fraction-free Bareiss updates.
+/// The resulting upper-triangular system is then lifted into [`BigRational`] for
+/// back-substitution, limiting rational arithmetic to the `O(D²)` phase.
+///
+/// # Errors
+/// Returns [`LaError::Singular`] if the matrix component table represents an
+/// exactly singular matrix.
+fn gauss_solve_components<const D: usize>(
+    m_components: [[Component; D]; D],
+    m_e_min: i32,
+    b_components: [Component; D],
+    b_e_min: i32,
+) -> Result<[BigRational; D], LaError> {
+    let mut e_min = m_e_min.min(b_e_min);
     if e_min == i32::MAX {
         e_min = 0;
     }
@@ -458,10 +432,6 @@ fn gauss_solve<const D: usize>(m: &Matrix<D>, b: &Vector<D>) -> Result<[BigRatio
         return Err(LaError::Singular { pivot_col });
     }
 
-    // Back-substitution in `BigRational`.  Only the upper triangle of `a`
-    // and the transformed `rhs` are read, each exactly once — so we
-    // `mem::take` instead of `clone` to avoid a per-entry allocation.
-    // `BigInt::default()` is the zero value and does not allocate.
     let mut x: [BigRational; D] = from_fn(|_| BigRational::from_integer(BigInt::from(0)));
     for i in (0..D).rev() {
         let mut sum = BigRational::from_integer(take(&mut rhs[i]));
@@ -474,6 +444,102 @@ fn gauss_solve<const D: usize>(m: &Matrix<D>, b: &Vector<D>) -> Result<[BigRatio
     }
 
     Ok(x)
+}
+
+impl<const D: usize> FiniteMatrix<D> {
+    /// Exact determinant for an already finite matrix.
+    #[inline]
+    fn det_exact(&self) -> BigRational {
+        bareiss_det_finite(self)
+    }
+
+    /// Exact determinant converted to a finite `f64`.
+    ///
+    /// # Errors
+    /// Returns [`LaError::Overflow`] if the exact determinant cannot be
+    /// represented as a finite `f64`.
+    #[inline]
+    fn det_exact_f64(&self) -> Result<f64, LaError> {
+        let exact = self.det_exact();
+        let Some(val) = exact.to_f64() else {
+            cold_path();
+            return Err(LaError::Overflow { index: None });
+        };
+        if val.is_finite() {
+            Ok(val)
+        } else {
+            cold_path();
+            Err(LaError::Overflow { index: None })
+        }
+    }
+
+    /// Exact linear solve for finite inputs.
+    ///
+    /// # Errors
+    /// Returns [`LaError::Singular`] if the matrix is exactly singular.
+    #[inline]
+    fn solve_exact(&self, b: FiniteVector<D>) -> Result<[BigRational; D], LaError> {
+        gauss_solve_finite(self, &b)
+    }
+
+    /// Exact linear solve converted to a finite `f64` vector.
+    ///
+    /// # Errors
+    /// Returns [`LaError::Singular`] if the matrix is exactly singular.
+    /// Returns [`LaError::Overflow`] if any exact solution component cannot be
+    /// represented as a finite `f64`.
+    #[inline]
+    fn solve_exact_f64(&self, b: FiniteVector<D>) -> Result<FiniteVector<D>, LaError> {
+        let exact = self.solve_exact(b)?;
+        let mut result = [0.0f64; D];
+        for (i, val) in exact.iter().enumerate() {
+            let Some(f) = val.to_f64() else {
+                cold_path();
+                return Err(LaError::Overflow { index: Some(i) });
+            };
+            if !f.is_finite() {
+                cold_path();
+                return Err(LaError::Overflow { index: Some(i) });
+            }
+            result[i] = f;
+        }
+        Ok(FiniteVector::new_unchecked(Vector::new(result)))
+    }
+
+    /// Exact determinant sign for an already finite matrix.
+    ///
+    /// The fast `f64` filter may reject overflowed scalar intermediates as
+    /// inconclusive, then fall back to integer Bareiss sign computation.
+    ///
+    /// # Errors
+    /// Returns [`LaError::NonFinite`] if a direct determinant or error-bound
+    /// computation detects a non-finite condition that is not an inconclusive
+    /// scalar overflow.
+    #[inline]
+    fn det_sign_exact(&self) -> Result<i8, LaError> {
+        match (self.det_direct(), self.det_errbound()) {
+            (Ok(Some(det_f64)), Ok(Some(err))) => {
+                if det_f64 > err {
+                    return Ok(1);
+                }
+                if det_f64 < -err {
+                    return Ok(-1);
+                }
+            }
+            (Err(LaError::NonFinite { row: None, .. }), _)
+            | (_, Err(LaError::NonFinite { row: None, .. })) => {}
+            (Err(err), _) | (_, Err(err)) => return Err(err),
+            _ => {}
+        }
+
+        cold_path();
+        let (det_int, _) = bareiss_det_int_finite(self);
+        Ok(match det_int.sign() {
+            Sign::Plus => 1,
+            Sign::Minus => -1,
+            Sign::NoSign => 0,
+        })
+    }
 }
 
 impl<const D: usize> Matrix<D> {
@@ -509,7 +575,7 @@ impl<const D: usize> Matrix<D> {
     /// Returns [`LaError::NonFinite`] if any matrix entry is NaN or infinite.
     #[inline]
     pub fn det_exact(&self) -> Result<BigRational, LaError> {
-        bareiss_det(self)
+        Ok(FiniteMatrix::try_new(*self)?.det_exact())
     }
 
     /// Exact determinant converted to `f64`.
@@ -539,17 +605,7 @@ impl<const D: usize> Matrix<D> {
     /// represent as a finite `f64`.
     #[inline]
     pub fn det_exact_f64(&self) -> Result<f64, LaError> {
-        let exact = self.det_exact()?;
-        let Some(val) = exact.to_f64() else {
-            cold_path();
-            return Err(LaError::Overflow { index: None });
-        };
-        if val.is_finite() {
-            Ok(val)
-        } else {
-            cold_path();
-            Err(LaError::Overflow { index: None })
-        }
+        FiniteMatrix::try_new(*self)?.det_exact_f64()
     }
 
     /// Exact linear system solve using hybrid integer/rational arithmetic.
@@ -600,7 +656,9 @@ impl<const D: usize> Matrix<D> {
     /// Returns [`LaError::Singular`] if the matrix is exactly singular.
     #[inline]
     pub fn solve_exact(&self, b: Vector<D>) -> Result<[BigRational; D], LaError> {
-        gauss_solve(self, &b)
+        let finite_m = FiniteMatrix::try_new(*self)?;
+        let finite_b = FiniteVector::try_new(b)?;
+        finite_m.solve_exact(finite_b)
     }
 
     /// Exact linear system solve converted to `f64`.
@@ -634,20 +692,9 @@ impl<const D: usize> Matrix<D> {
     /// too large to represent as a finite `f64`.
     #[inline]
     pub fn solve_exact_f64(&self, b: Vector<D>) -> Result<Vector<D>, LaError> {
-        let exact = self.solve_exact(b)?;
-        let mut result = [0.0f64; D];
-        for (i, val) in exact.iter().enumerate() {
-            let Some(f) = val.to_f64() else {
-                cold_path();
-                return Err(LaError::Overflow { index: Some(i) });
-            };
-            if !f.is_finite() {
-                cold_path();
-                return Err(LaError::Overflow { index: Some(i) });
-            }
-            result[i] = f;
-        }
-        Ok(Vector::new(result))
+        let finite_m = FiniteMatrix::try_new(*self)?;
+        let finite_b = FiniteVector::try_new(b)?;
+        Ok(finite_m.solve_exact_f64(finite_b)?.into_vector())
     }
 
     /// Exact determinant sign using adaptive-precision arithmetic.
@@ -690,43 +737,7 @@ impl<const D: usize> Matrix<D> {
     /// Returns [`LaError::NonFinite`] if any matrix entry is NaN or infinite.
     #[inline]
     pub fn det_sign_exact(&self) -> Result<i8, LaError> {
-        // Stage 1: f64 fast filter for D ≤ 4.
-        //
-        // When entries are large (e.g. near f64::MAX), the f64 determinant or
-        // its error bound can overflow even though every individual entry is
-        // finite. In that case the fast filter is inconclusive; fall through to
-        // the exact Bareiss path. Stored NaN/±∞ entries are still rejected
-        // immediately with their source coordinates.
-        match (self.det_direct(), self.det_errbound()) {
-            (Ok(Some(det_f64)), Ok(Some(err))) => {
-                if det_f64 > err {
-                    return Ok(1);
-                }
-                if det_f64 < -err {
-                    return Ok(-1);
-                }
-            }
-            (Err(err @ LaError::NonFinite { row: Some(_), .. }), _)
-            | (_, Err(err @ LaError::NonFinite { row: Some(_), .. })) => return Err(err),
-            (Err(LaError::NonFinite { row: None, .. }), _)
-            | (_, Err(LaError::NonFinite { row: None, .. })) => {}
-            (Err(err), _) | (_, Err(err)) => return Err(err),
-            _ => {}
-        }
-
-        // Stage 2: integer Bareiss fallback — the 2^(D×e_min) scale factor
-        // is always positive, so det_int.sign() == det(A).sign().  This is
-        // the cold path: the fast filter resolves the vast majority of
-        // well-conditioned calls without allocating.  `bareiss_det_int`
-        // validates finiteness via `decompose_matrix`, so NaN/±∞ inputs
-        // surface here as `Err(LaError::NonFinite)`.
-        cold_path();
-        let (det_int, _) = bareiss_det_int(self)?;
-        Ok(match det_int.sign() {
-            Sign::Plus => 1,
-            Sign::Minus => -1,
-            Sign::NoSign => 0,
-        })
+        FiniteMatrix::try_new(*self)?.det_sign_exact()
     }
 }
 
@@ -780,6 +791,37 @@ mod tests {
     // -----------------------------------------------------------------------
     // Macro-generated per-dimension tests (D=2..5)
     // -----------------------------------------------------------------------
+
+    macro_rules! gen_internal_finite_exact_tests {
+        ($d:literal) => {
+            paste! {
+                #[test]
+                fn [<internal_finite_exact_paths_reuse_validation_ $d d>]() {
+                    let a = FiniteMatrix::<$d>::try_new(Matrix::<$d>::identity()).unwrap();
+                    let b = FiniteVector::<$d>::try_new(Vector::<$d>::new([1.0; $d])).unwrap();
+
+                    assert_eq!(a.det_exact(), BigRational::from_integer(BigInt::from(1)));
+                    assert!((a.det_exact_f64().unwrap() - 1.0).abs() <= f64::EPSILON);
+                    assert_eq!(a.det_sign_exact().unwrap(), 1);
+
+                    let exact = a.solve_exact(b).unwrap();
+                    for value in exact {
+                        assert_eq!(value, BigRational::from_integer(BigInt::from(1)));
+                    }
+
+                    let exact_f64 = a.solve_exact_f64(b).unwrap();
+                    for value in exact_f64.into_array() {
+                        assert!((value - 1.0).abs() <= f64::EPSILON);
+                    }
+                }
+            }
+        };
+    }
+
+    gen_internal_finite_exact_tests!(2);
+    gen_internal_finite_exact_tests!(3);
+    gen_internal_finite_exact_tests!(4);
+    gen_internal_finite_exact_tests!(5);
 
     macro_rules! gen_det_exact_tests {
         ($d:literal) => {
@@ -1231,7 +1273,8 @@ mod tests {
 
     #[test]
     fn bareiss_det_int_d0() {
-        let (det, exp) = bareiss_det_int(&Matrix::<0>::zero()).unwrap();
+        let m = FiniteMatrix::try_new(Matrix::<0>::zero()).unwrap();
+        let (det, exp) = bareiss_det_int_finite(&m);
         assert_eq!(det, BigInt::from(1));
         assert_eq!(exp, 0);
     }
@@ -1251,7 +1294,8 @@ mod tests {
             (0.5, 1, -1),   // 0.5  =  1 × 2^(-1)
         ];
         for &(input, expected_det_int, expected_exp) in cases {
-            let (det, exp) = bareiss_det_int(&Matrix::<1>::from_rows([[input]])).unwrap();
+            let m = FiniteMatrix::try_new(Matrix::<1>::from_rows([[input]])).unwrap();
+            let (det, exp) = bareiss_det_int_finite(&m);
             assert_eq!(
                 det,
                 BigInt::from(expected_det_int),
@@ -1264,8 +1308,8 @@ mod tests {
     #[test]
     fn bareiss_det_int_d2_known() {
         // det([[1,2],[3,4]]) = -2
-        let m = Matrix::<2>::from_rows([[1.0, 2.0], [3.0, 4.0]]);
-        let (det_int, total_exp) = bareiss_det_int(&m).unwrap();
+        let m = FiniteMatrix::try_new(Matrix::<2>::from_rows([[1.0, 2.0], [3.0, 4.0]])).unwrap();
+        let (det_int, total_exp) = bareiss_det_int_finite(&m);
         // Reconstruct and verify.
         let det = bigint_exp_to_bigrational(det_int, total_exp);
         assert_eq!(det, BigRational::from_integer(BigInt::from(-2)));
@@ -1273,15 +1317,21 @@ mod tests {
 
     #[test]
     fn bareiss_det_int_all_zeros() {
-        let (det, _) = bareiss_det_int(&Matrix::<3>::zero()).unwrap();
+        let m = FiniteMatrix::try_new(Matrix::<3>::zero()).unwrap();
+        let (det, _) = bareiss_det_int_finite(&m);
         assert_eq!(det, BigInt::from(0));
     }
 
     #[test]
     fn bareiss_det_int_sign_matches_det_sign_exact() {
         // The sign of det_int should match det_sign_exact for various matrices.
-        let m = Matrix::<3>::from_rows([[0.0, 1.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, 1.0]]);
-        let (det_int, _) = bareiss_det_int(&m).unwrap();
+        let m = FiniteMatrix::try_new(Matrix::<3>::from_rows([
+            [0.0, 1.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [0.0, 0.0, 1.0],
+        ]))
+        .unwrap();
+        let (det_int, _) = bareiss_det_int_finite(&m);
         assert_eq!(det_int.sign(), Sign::Minus); // det = -1
     }
 
@@ -1289,8 +1339,8 @@ mod tests {
     fn bareiss_det_int_fractional_entries() {
         // Entries with negative exponents: 0.5 = 1×2^(-1), 0.25 = 1×2^(-2).
         // det([[0.5, 0.25], [1.0, 1.0]]) = 0.5×1.0 − 0.25×1.0 = 0.25
-        let m = Matrix::<2>::from_rows([[0.5, 0.25], [1.0, 1.0]]);
-        let (det_int, total_exp) = bareiss_det_int(&m).unwrap();
+        let m = FiniteMatrix::try_new(Matrix::<2>::from_rows([[0.5, 0.25], [1.0, 1.0]])).unwrap();
+        let (det_int, total_exp) = bareiss_det_int_finite(&m);
         let det = bigint_exp_to_bigrational(det_int, total_exp);
         assert_eq!(det, BigRational::new(BigInt::from(1), BigInt::from(4)));
     }
@@ -1298,8 +1348,13 @@ mod tests {
     #[test]
     fn bareiss_det_int_d3_with_pivoting() {
         // Zero on diagonal → exercises pivot swap inside bareiss_det_int.
-        let m = Matrix::<3>::from_rows([[0.0, 1.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, 1.0]]);
-        let (det_int, total_exp) = bareiss_det_int(&m).unwrap();
+        let m = FiniteMatrix::try_new(Matrix::<3>::from_rows([
+            [0.0, 1.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [0.0, 0.0, 1.0],
+        ]))
+        .unwrap();
+        let (det_int, total_exp) = bareiss_det_int_finite(&m);
         let det = bigint_exp_to_bigrational(det_int, total_exp);
         assert_eq!(det, BigRational::from_integer(BigInt::from(-1)));
     }
@@ -1311,7 +1366,7 @@ mod tests {
         let mut m = Matrix::<3>::identity();
         assert_eq!(m.set(1, 2, f64::NAN), Some(()));
         assert_eq!(
-            bareiss_det_int(&m),
+            m.det_exact(),
             Err(LaError::NonFinite {
                 row: Some(1),
                 col: 2
@@ -1324,7 +1379,7 @@ mod tests {
         let mut m = Matrix::<2>::identity();
         assert_eq!(m.set(0, 0, f64::INFINITY), Some(()));
         assert_eq!(
-            bareiss_det_int(&m),
+            m.det_exact(),
             Err(LaError::NonFinite {
                 row: Some(0),
                 col: 0
@@ -1338,8 +1393,8 @@ mod tests {
             paste! {
                 #[test]
                 fn [<bareiss_det_int_identity_ $d d>]() {
-                    let (det_int, total_exp) =
-                        bareiss_det_int(&Matrix::<$d>::identity()).unwrap();
+                    let m = FiniteMatrix::try_new(Matrix::<$d>::identity()).unwrap();
+                    let (det_int, total_exp) = bareiss_det_int_finite(&m);
                     let det = bigint_exp_to_bigrational(det_int, total_exp);
                     assert_eq!(det, BigRational::from_integer(BigInt::from(1)));
                 }
@@ -1406,13 +1461,13 @@ mod tests {
 
     #[test]
     fn bareiss_det_d0_is_one() {
-        let det = bareiss_det(&Matrix::<0>::zero()).unwrap();
+        let det = Matrix::<0>::zero().det_exact().unwrap();
         assert_eq!(det, BigRational::from_integer(BigInt::from(1)));
     }
 
     #[test]
     fn bareiss_det_d1_returns_entry() {
-        let det = bareiss_det(&Matrix::<1>::from_rows([[7.0]])).unwrap();
+        let det = Matrix::<1>::from_rows([[7.0]]).det_exact().unwrap();
         assert_eq!(det, f64_to_bigrational(7.0));
     }
 
@@ -1420,7 +1475,7 @@ mod tests {
     fn bareiss_det_d3_with_pivoting() {
         // First column has zero on diagonal → exercises pivot swap + break.
         let m = Matrix::<3>::from_rows([[0.0, 1.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, 1.0]]);
-        let det = bareiss_det(&m).unwrap();
+        let det = m.det_exact().unwrap();
         // det of this permutation matrix = -1
         assert_eq!(det, BigRational::from_integer(BigInt::from(-1)));
     }
@@ -1429,7 +1484,7 @@ mod tests {
     fn bareiss_det_singular_all_zeros_in_column() {
         // Column 1 is all zeros below diagonal after elimination → singular.
         let m = Matrix::<3>::from_rows([[1.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 1.0]]);
-        let det = bareiss_det(&m).unwrap();
+        let det = m.det_exact().unwrap();
         assert_eq!(det, BigRational::from_integer(BigInt::from(0)));
     }
 
@@ -2255,21 +2310,21 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // gauss_solve: internal helper tests
+    // exact solve boundary tests
     // -----------------------------------------------------------------------
 
     #[test]
     fn gauss_solve_d0_returns_empty() {
         let a = Matrix::<0>::zero();
         let b = Vector::<0>::zero();
-        assert_eq!(gauss_solve(&a, &b).unwrap().len(), 0);
+        assert_eq!(a.solve_exact(b).unwrap().len(), 0);
     }
 
     #[test]
     fn gauss_solve_d1() {
         let a = Matrix::<1>::from_rows([[2.0]]);
         let b = Vector::<1>::new([6.0]);
-        let x = gauss_solve(&a, &b).unwrap();
+        let x = a.solve_exact(b).unwrap();
         assert_eq!(x[0], f64_to_bigrational(3.0));
     }
 
@@ -2277,7 +2332,7 @@ mod tests {
     fn gauss_solve_singular_column_all_zero() {
         let a = Matrix::<3>::from_rows([[1.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 1.0]]);
         let b = Vector::<3>::new([1.0, 2.0, 3.0]);
-        assert_eq!(gauss_solve(&a, &b), Err(LaError::Singular { pivot_col: 1 }));
+        assert_eq!(a.solve_exact(b), Err(LaError::Singular { pivot_col: 1 }));
     }
 
     // -----------------------------------------------------------------------

--- a/src/exact.rs
+++ b/src/exact.rs
@@ -405,9 +405,15 @@ fn gauss_solve_finite<const D: usize>(
 
 /// Solve an exact integer-scaled augmented system from decomposed components.
 ///
-/// Forward elimination runs in [`BigInt`] using fraction-free Bareiss updates.
-/// The resulting upper-triangular system is then lifted into [`BigRational`] for
-/// back-substitution, limiting rational arithmetic to the `O(D²)` phase.
+/// Forward elimination runs in [`BigInt`] using fraction-free Bareiss updates
+/// [7]. This is exact arithmetic, so there is no floating-point conditioning or
+/// roundoff error in the elimination itself; ill-conditioned inputs can still
+/// produce large exact numerators and denominators in the final solution. The
+/// elimination phase performs `O(D³)` integer operations and Bareiss exact
+/// division controls intermediate integer growth compared with naive fraction
+/// arithmetic. The resulting upper-triangular system is then lifted into
+/// [`BigRational`] for back-substitution, limiting rational arithmetic to the
+/// `O(D²)` phase.
 ///
 /// # Errors
 /// Returns [`LaError::Singular`] if the matrix component table represents an

--- a/src/ldlt.rs
+++ b/src/ldlt.rs
@@ -13,9 +13,9 @@
 
 use core::hint::cold_path;
 
-use crate::matrix::Matrix;
-use crate::vector::Vector;
-use crate::{LDLT_SYMMETRY_REL_TOL, LaError, Tolerance};
+use crate::matrix::{Matrix, SymmetricMatrix};
+use crate::vector::{FiniteVector, Vector};
+use crate::{LaError, Tolerance};
 
 /// LDLT factorization (`A = L D Lᵀ`) for symmetric positive (semi)definite matrices.
 ///
@@ -41,21 +41,10 @@ pub struct Ldlt<const D: usize> {
 }
 
 impl<const D: usize> Ldlt<D> {
-    /// Factor a symmetric square matrix into in-place LDLT storage for [`Matrix::ldlt`].
-    ///
-    /// This is the single validation boundary for LDLT construction: it rejects
-    /// invalid tolerances, asymmetric inputs, non-finite values, and degenerate
-    /// diagonals before callers can observe an [`Ldlt`] value.
-    #[inline]
-    pub(crate) fn factor(a: Matrix<D>, tol: Tolerance) -> Result<Self, LaError> {
-        reject_asymmetric(&a)?;
-        Self::factor_symmetric(a, tol)
-    }
-
     /// Factor a matrix that has already passed LDLT symmetry validation.
     #[inline]
-    pub(crate) fn factor_symmetric(a: Matrix<D>, tol: Tolerance) -> Result<Self, LaError> {
-        let mut f = a;
+    pub(crate) fn factor_symmetric(a: SymmetricMatrix<D>, tol: Tolerance) -> Result<Self, LaError> {
+        let mut f = a.into_matrix();
 
         // LDLT via symmetric rank-1 updates, using only the lower triangle.
         for j in 0..D {
@@ -63,6 +52,10 @@ impl<const D: usize> Ldlt<D> {
             if !d.is_finite() {
                 cold_path();
                 return Err(LaError::non_finite_cell(j, j));
+            }
+            if d < 0.0 {
+                cold_path();
+                return Err(LaError::not_positive_semidefinite(j, d));
             }
             if d <= tol.get() {
                 cold_path();
@@ -155,8 +148,11 @@ impl<const D: usize> Ldlt<D> {
     /// ```
     ///
     /// # Errors
-    /// Returns [`LaError::Singular`] if a diagonal entry `d = D[i,i]` satisfies `d <= tol`
-    /// (non-positive or too small), where `tol` is the tolerance that was used during factorization.
+    /// Returns [`LaError::NotPositiveSemidefinite`] if a diagonal entry
+    /// `d = D[i,i]` is negative.
+    ///
+    /// Returns [`LaError::Singular`] if a diagonal entry `d = D[i,i]` satisfies
+    /// `0 <= d <= tol`, where `tol` is the tolerance that was used during factorization.
     ///
     /// Returns [`LaError::NonFinite`] if NaN/∞ is detected. The `row`/`col` coordinates
     /// follow the convention documented on [`LaError::NonFinite`]:
@@ -168,7 +164,37 @@ impl<const D: usize> Ldlt<D> {
     ///   accumulator or the quotient `x[i] / diag`) overflowed to NaN/∞ at step `i`.
     #[inline]
     pub const fn solve_vec(&self, b: Vector<D>) -> Result<Vector<D>, LaError> {
-        let mut x = b.data;
+        match FiniteVector::try_new(b) {
+            Ok(finite) => match self.solve_finite_vec(finite) {
+                Ok(x) => Ok(x.into_vector()),
+                Err(err) => Err(err),
+            },
+            Err(err) => Err(err),
+        }
+    }
+
+    /// Solve `A x = b` using this LDLT factorization and a finite right-hand side.
+    ///
+    /// The right-hand side entries are known finite, so this path only checks
+    /// factorization defensive invariants and computed substitution overflows.
+    ///
+    /// # Errors
+    /// Returns [`LaError::NotPositiveSemidefinite`] if a diagonal entry
+    /// `d = D[i,i]` is negative.
+    ///
+    /// Returns [`LaError::Singular`] if a diagonal entry `d = D[i,i]` satisfies
+    /// `0 <= d <= tol`, where `tol` is the tolerance that was used during
+    /// factorization.
+    ///
+    /// Returns [`LaError::NonFinite`] if a stored factorization diagonal is
+    /// corrupt or if a computed substitution intermediate overflows to NaN or
+    /// infinity.
+    #[inline]
+    pub(crate) const fn solve_finite_vec(
+        &self,
+        b: FiniteVector<D>,
+    ) -> Result<FiniteVector<D>, LaError> {
+        let mut x = b.into_array();
 
         // Forward substitution: L y = b (L has unit diagonal).
         let mut i = 0;
@@ -199,6 +225,10 @@ impl<const D: usize> Ldlt<D> {
             if !diag.is_finite() {
                 cold_path();
                 return Err(LaError::non_finite_cell(i, i));
+            }
+            if diag < 0.0 {
+                cold_path();
+                return Err(LaError::not_positive_semidefinite(i, diag));
             }
             if diag <= self.tol.get() {
                 cold_path();
@@ -232,21 +262,7 @@ impl<const D: usize> Ldlt<D> {
             ii += 1;
         }
 
-        Ok(Vector::new(x))
-    }
-}
-
-/// Reject asymmetric matrices before the no-pivot LDLT algorithm reads only the lower triangle.
-///
-/// This preserves the public [`Matrix::ldlt`] contract: an input that would
-/// otherwise produce a factorization for a different implicit matrix returns
-/// [`LaError::Asymmetric`] instead.
-fn reject_asymmetric<const D: usize>(a: &Matrix<D>) -> Result<(), LaError> {
-    if let Some((row, col)) = a.first_asymmetry(LDLT_SYMMETRY_REL_TOL)? {
-        cold_path();
-        Err(LaError::asymmetric(row, col, D))
-    } else {
-        Ok(())
+        Ok(FiniteVector::new_unchecked(Vector::new(x)))
     }
 }
 
@@ -255,6 +271,7 @@ mod tests {
     use super::*;
 
     use crate::DEFAULT_SINGULAR_TOL;
+    use crate::matrix::FiniteMatrix;
 
     use core::assert_matches;
     use core::hint::black_box;
@@ -355,7 +372,10 @@ mod tests {
     #[test]
     fn solve_2x2_known_spd() {
         let a = Matrix::<2>::from_rows(black_box([[4.0, 2.0], [2.0, 3.0]]));
-        let ldlt = (black_box(Ldlt::<2>::factor))(a, DEFAULT_SINGULAR_TOL).unwrap();
+        let ldlt = FiniteMatrix::try_new(a)
+            .unwrap()
+            .ldlt(DEFAULT_SINGULAR_TOL)
+            .unwrap();
 
         let b = Vector::<2>::new(black_box([1.0, 2.0]));
         let x = ldlt.solve_vec(b).unwrap().into_array();
@@ -389,6 +409,32 @@ mod tests {
         let a = Matrix::<2>::from_rows(black_box([[1.0, 1.0], [1.0, 1.0]]));
         let err = a.ldlt(DEFAULT_SINGULAR_TOL).unwrap_err();
         assert_eq!(err, LaError::Singular { pivot_col: 1 });
+    }
+
+    #[test]
+    fn negative_initial_diagonal_reports_not_positive_semidefinite() {
+        let a = Matrix::<2>::from_rows(black_box([[-1.0, 0.0], [0.0, 1.0]]));
+        let err = a.ldlt(DEFAULT_SINGULAR_TOL).unwrap_err();
+        assert_eq!(
+            err,
+            LaError::NotPositiveSemidefinite {
+                pivot_col: 0,
+                value: -1.0,
+            }
+        );
+    }
+
+    #[test]
+    fn negative_updated_diagonal_reports_not_positive_semidefinite() {
+        let a = Matrix::<2>::from_rows(black_box([[1.0, 2.0], [2.0, 1.0]]));
+        let err = a.ldlt(DEFAULT_SINGULAR_TOL).unwrap_err();
+        assert_eq!(
+            err,
+            LaError::NotPositiveSemidefinite {
+                pivot_col: 1,
+                value: -3.0,
+            }
+        );
     }
 
     #[test]
@@ -577,9 +623,31 @@ mod tests {
                     );
                 }
 
+                /// `solve_vec` must surface `NotPositiveSemidefinite` when a
+                /// stored diagonal is negative, even though `ldlt` cannot
+                /// produce such a factorization.
+                #[test]
+                fn [<solve_vec_defensive_negative_diagonal_ $d d>]() {
+                    let mut factors = Matrix::<$d>::identity();
+                    factors.rows[$d - 1][$d - 1] = -1.0;
+                    let ldlt = Ldlt::<$d> {
+                        factors,
+                        tol: DEFAULT_SINGULAR_TOL,
+                    };
+                    let b = Vector::<$d>::new([1.0; $d]);
+                    let err = ldlt.solve_vec(b).unwrap_err();
+                    assert_eq!(
+                        err,
+                        LaError::NotPositiveSemidefinite {
+                            pivot_col: $d - 1,
+                            value: -1.0,
+                        }
+                    );
+                }
+
                 /// `solve_vec` must surface `Singular` when a stored
-                /// diagonal is at or below the recorded tolerance, even
-                /// though `factor` cannot produce such a factorization.
+                /// non-negative diagonal is at or below the recorded tolerance,
+                /// even though `ldlt` cannot produce such a factorization.
                 #[test]
                 fn [<solve_vec_defensive_sub_tolerance_diagonal_ $d d>]() {
                     let mut factors = Matrix::<$d>::identity();

--- a/src/ldlt.rs
+++ b/src/ldlt.rs
@@ -154,14 +154,18 @@ impl<const D: usize> Ldlt<D> {
     /// Returns [`LaError::Singular`] if a diagonal entry `d = D[i,i]` satisfies
     /// `0 <= d <= tol`, where `tol` is the tolerance that was used during factorization.
     ///
-    /// Returns [`LaError::NonFinite`] if NaN/∞ is detected. The `row`/`col` coordinates
-    /// follow the convention documented on [`LaError::NonFinite`]:
+    /// Returns [`LaError::NonFinite`] if NaN/∞ is detected. If
+    /// `FiniteVector::try_new(b)` rejects a non-finite RHS entry, the error uses
+    /// `row: None` and `col: i`, where `i` is the offending vector index. The
+    /// `row`/`col` coordinates follow the convention documented on
+    /// [`LaError::NonFinite`]:
     ///
     /// - `row: Some(i), col: i` — the stored `D` diagonal at `(i, i)` is non-finite
     ///   (only reachable via direct `Ldlt` construction; [`Matrix::ldlt`](crate::Matrix::ldlt)
     ///   rejects such factorizations).
-    /// - `row: None, col: i` — a computed intermediate (forward/back-substitution
-    ///   accumulator or the quotient `x[i] / diag`) overflowed to NaN/∞ at step `i`.
+    /// - `row: None, col: i` — either RHS entry `b[i]` is non-finite, or a
+    ///   computed intermediate (forward/back-substitution accumulator or the
+    ///   quotient `x[i] / diag`) overflowed to NaN/∞ at step `i`.
     #[inline]
     pub const fn solve_vec(&self, b: Vector<D>) -> Result<Vector<D>, LaError> {
         match FiniteVector::try_new(b) {
@@ -659,6 +663,24 @@ mod tests {
                     let b = Vector::<$d>::new([1.0; $d]);
                     let err = ldlt.solve_vec(b).unwrap_err();
                     assert_eq!(err, LaError::Singular { pivot_col: $d - 1 });
+                }
+
+                /// `solve_vec` rejects raw non-finite right-hand sides before
+                /// entering the finite-RHS solve path.
+                #[test]
+                fn [<solve_vec_rejects_non_finite_rhs_ $d d>]() {
+                    let ldlt = Matrix::<$d>::identity().ldlt(DEFAULT_SINGULAR_TOL).unwrap();
+                    let mut rhs = [1.0; $d];
+                    rhs[$d - 1] = f64::NAN;
+
+                    let err = ldlt.solve_vec(Vector::<$d>::new(rhs)).unwrap_err();
+                    assert_eq!(
+                        err,
+                        LaError::NonFinite {
+                            row: None,
+                            col: $d - 1,
+                        }
+                    );
                 }
             }
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,6 +109,10 @@ const EPS: f64 = f64::EPSILON; // 2^-52
 
 /// Absolute error coefficient for [`Matrix::<2>::det_direct`](crate::Matrix::det_direct).
 ///
+/// This constant is not a caller-tuned tolerance. It is the dimension-specific
+/// multiplier that turns the matrix's absolute Leibniz sum into a conservative
+/// bound on floating-point roundoff in the closed-form 2×2 determinant formula.
+///
 /// For any 2×2 matrix `A = [[a, b], [c, d]]` with finite f64 entries,
 ///
 /// ```text
@@ -150,6 +154,10 @@ pub const ERR_COEFF_2: f64 = 3.0 * EPS + 16.0 * EPS * EPS;
 
 /// Absolute error coefficient for [`Matrix::<3>::det_direct`](crate::Matrix::det_direct).
 ///
+/// This constant is not a caller-tuned tolerance. It is the dimension-specific
+/// multiplier that turns the matrix's absolute Leibniz sum into a conservative
+/// bound on floating-point roundoff in the closed-form 3×3 determinant formula.
+///
 /// For any 3×3 matrix `A` with finite f64 entries,
 ///
 /// ```text
@@ -167,6 +175,10 @@ pub const ERR_COEFF_2: f64 = 3.0 * EPS + 16.0 * EPS * EPS;
 pub const ERR_COEFF_3: f64 = 8.0 * EPS + 64.0 * EPS * EPS;
 
 /// Absolute error coefficient for [`Matrix::<4>::det_direct`](crate::Matrix::det_direct).
+///
+/// This constant is not a caller-tuned tolerance. It is the dimension-specific
+/// multiplier that turns the matrix's absolute Leibniz sum into a conservative
+/// bound on floating-point roundoff in the closed-form 4×4 determinant formula.
 ///
 /// For any 4×4 matrix `A` with finite f64 entries,
 ///
@@ -351,6 +363,13 @@ pub enum LaError {
         /// Matrix dimension `D`.
         dim: usize,
     },
+    /// A symmetric matrix failed the positive-semidefinite LDLT domain check.
+    NotPositiveSemidefinite {
+        /// Factorization column/step where a negative LDLT diagonal was found.
+        pivot_col: usize,
+        /// Negative diagonal value observed at that step.
+        value: f64,
+    },
 }
 
 impl LaError {
@@ -490,6 +509,26 @@ impl LaError {
         Self::Asymmetric { row, col, dim }
     }
 
+    /// Construct a [`LaError::NotPositiveSemidefinite`] for LDLT factorization.
+    ///
+    /// # Examples
+    /// ```
+    /// use la_stack::prelude::*;
+    ///
+    /// assert_eq!(
+    ///     LaError::not_positive_semidefinite(1, -3.0),
+    ///     LaError::NotPositiveSemidefinite {
+    ///         pivot_col: 1,
+    ///         value: -3.0,
+    ///     }
+    /// );
+    /// ```
+    #[inline]
+    #[must_use]
+    pub const fn not_positive_semidefinite(pivot_col: usize, value: f64) -> Self {
+        Self::NotPositiveSemidefinite { pivot_col, value }
+    }
+
     /// Parse a raw tolerance into a finite, non-negative [`Tolerance`].
     ///
     /// # Examples
@@ -560,6 +599,12 @@ impl fmt::Display for LaError {
                     "matrix is not symmetric for dimension {dim}: asymmetric pair ({row}, {col})"
                 )
             }
+            Self::NotPositiveSemidefinite { pivot_col, value } => {
+                write!(
+                    f,
+                    "matrix is not positive semidefinite at LDLT pivot column {pivot_col}: diagonal value {value} < 0"
+                )
+            }
         }
     }
 }
@@ -568,7 +613,7 @@ impl std::error::Error for LaError {}
 
 pub use ldlt::Ldlt;
 pub use lu::Lu;
-pub use matrix::{Matrix, SymmetricMatrix};
+pub use matrix::Matrix;
 pub use vector::Vector;
 
 /// Fallibly dispatch a runtime dimension to a concrete stack-allocated matrix.
@@ -654,11 +699,11 @@ macro_rules! try_with_stack_matrix {
 
 /// Common imports for ergonomic usage.
 ///
-/// This prelude re-exports the primary types and constants: [`Matrix`], [`SymmetricMatrix`],
-/// [`Vector`], [`Lu`], [`Ldlt`], [`Tolerance`], [`LaError`], [`DEFAULT_PIVOT_TOL`],
-/// [`DEFAULT_SINGULAR_TOL`], and the determinant error bound coefficients
-/// [`ERR_COEFF_2`], [`ERR_COEFF_3`], and [`ERR_COEFF_4`]. It also re-exports
-/// [`MAX_STACK_MATRIX_DISPATCH_DIM`] and
+/// This prelude re-exports the primary types and constants: [`Matrix`],
+/// [`Vector`], [`Lu`], [`Ldlt`], [`Tolerance`], [`LaError`],
+/// [`DEFAULT_PIVOT_TOL`], [`DEFAULT_SINGULAR_TOL`], and the determinant error
+/// bound coefficients [`ERR_COEFF_2`], [`ERR_COEFF_3`], and [`ERR_COEFF_4`].
+/// It also re-exports [`MAX_STACK_MATRIX_DISPATCH_DIM`] and
 /// [`try_with_stack_matrix!`] for runtime-to-const matrix dispatch.
 ///
 /// When the `exact` feature is enabled, [`BigInt`] and [`BigRational`]
@@ -672,8 +717,7 @@ macro_rules! try_with_stack_matrix {
 pub mod prelude {
     pub use crate::{
         DEFAULT_PIVOT_TOL, DEFAULT_SINGULAR_TOL, ERR_COEFF_2, ERR_COEFF_3, ERR_COEFF_4, LaError,
-        Ldlt, Lu, MAX_STACK_MATRIX_DISPATCH_DIM, Matrix, SymmetricMatrix, Tolerance, Vector,
-        try_with_stack_matrix,
+        Ldlt, Lu, MAX_STACK_MATRIX_DISPATCH_DIM, Matrix, Tolerance, Vector, try_with_stack_matrix,
     };
 
     #[cfg(feature = "exact")]
@@ -853,6 +897,18 @@ mod tests {
     }
 
     #[test]
+    fn laerror_display_formats_not_positive_semidefinite() {
+        let err = LaError::NotPositiveSemidefinite {
+            pivot_col: 1,
+            value: -3.0,
+        };
+        assert_eq!(
+            err.to_string(),
+            "matrix is not positive semidefinite at LDLT pivot column 1: diagonal value -3 < 0"
+        );
+    }
+
+    #[test]
     fn laerror_is_std_error_with_no_source() {
         let err = LaError::Singular { pivot_col: 0 };
         let e: &dyn std::error::Error = &err;
@@ -867,12 +923,7 @@ mod tests {
         let m = Matrix::<2>::identity();
         let v = Vector::<2>::new([1.0, 2.0]);
         let _ = m.lu(DEFAULT_PIVOT_TOL).unwrap().solve_vec(v).unwrap();
-        let symmetric = SymmetricMatrix::try_new(m).unwrap();
-        let _ = symmetric
-            .ldlt(DEFAULT_SINGULAR_TOL)
-            .unwrap()
-            .solve_vec(v)
-            .unwrap();
+        let _ = m.ldlt(DEFAULT_SINGULAR_TOL).unwrap().solve_vec(v).unwrap();
         assert_eq!(MAX_STACK_MATRIX_DISPATCH_DIM, 7);
     }
 

--- a/src/lu.rs
+++ b/src/lu.rs
@@ -2,8 +2,8 @@
 
 use core::hint::cold_path;
 
-use crate::matrix::Matrix;
-use crate::vector::Vector;
+use crate::matrix::{FiniteMatrix, Matrix};
+use crate::vector::{FiniteVector, Vector};
 use crate::{LaError, Tolerance};
 
 /// LU decomposition (PA = LU) with partial pivoting.
@@ -17,17 +17,17 @@ pub struct Lu<const D: usize> {
 }
 
 impl<const D: usize> Lu<D> {
-    /// Factor a square matrix into in-place LU storage for [`Matrix::lu`](crate::Matrix::lu).
+    /// Factor a finite square matrix into in-place LU storage for
+    /// `FiniteMatrix::lu`.
     ///
-    /// This is the single validation boundary for LU construction: it rejects
-    /// invalid tolerances, non-finite pivot candidates, non-finite elimination
-    /// intermediates, and numerically singular pivots before callers can observe
-    /// a [`Lu`] value.  Computed trailing updates are checked before storage so
-    /// successful factors do not contain a non-finite value produced during
-    /// elimination.
+    /// The input has already proven finite entries, so LU construction rejects
+    /// numerically singular pivots and non-finite elimination intermediates
+    /// before callers can observe a [`Lu`] value. Computed trailing updates are
+    /// checked before storage so successful factors do not contain a non-finite
+    /// value produced during elimination.
     #[inline]
-    pub(crate) fn factor(a: Matrix<D>, tol: Tolerance) -> Result<Self, LaError> {
-        let mut lu = a;
+    pub(crate) fn factor_finite(a: FiniteMatrix<D>, tol: Tolerance) -> Result<Self, LaError> {
+        let mut lu = a.into_matrix();
 
         let mut piv = [0usize; D];
         for (i, p) in piv.iter_mut().enumerate() {
@@ -40,17 +40,9 @@ impl<const D: usize> Lu<D> {
             // Choose pivot row.
             let mut pivot_row = k;
             let mut pivot_abs = lu.rows[k][k].abs();
-            if !pivot_abs.is_finite() {
-                cold_path();
-                return Err(LaError::non_finite_cell(k, k));
-            }
 
             for r in (k + 1)..D {
                 let v = lu.rows[r][k].abs();
-                if !v.is_finite() {
-                    cold_path();
-                    return Err(LaError::non_finite_cell(r, k));
-                }
                 if v > pivot_abs {
                     pivot_abs = v;
                     pivot_row = r;
@@ -69,10 +61,6 @@ impl<const D: usize> Lu<D> {
             }
 
             let pivot = lu.rows[k][k];
-            if !pivot.is_finite() {
-                cold_path();
-                return Err(LaError::non_finite_cell(k, k));
-            }
 
             // Eliminate below pivot.
             for r in (k + 1)..D {
@@ -135,10 +123,38 @@ impl<const D: usize> Lu<D> {
     ///   accumulator or the quotient `sum / diag`) overflowed to NaN/∞ at step `i`.
     #[inline]
     pub const fn solve_vec(&self, b: Vector<D>) -> Result<Vector<D>, LaError> {
+        match FiniteVector::try_new(b) {
+            Ok(finite) => match self.solve_finite_vec(finite) {
+                Ok(x) => Ok(x.into_vector()),
+                Err(err) => Err(err),
+            },
+            Err(err) => Err(err),
+        }
+    }
+
+    /// Solve `A x = b` using this LU factorization and a finite right-hand side.
+    ///
+    /// The right-hand side entries are known finite, so this path only checks
+    /// factorization defensive invariants and computed substitution overflows.
+    ///
+    /// # Errors
+    /// Returns [`LaError::Singular`] if a diagonal entry of `U` satisfies
+    /// `|u_ii| <= tol`, where `tol` is the tolerance that was used during
+    /// factorization.
+    ///
+    /// Returns [`LaError::NonFinite`] if a stored factorization diagonal is
+    /// corrupt or if a computed substitution intermediate overflows to NaN or
+    /// infinity.
+    #[inline]
+    pub(crate) const fn solve_finite_vec(
+        &self,
+        b: FiniteVector<D>,
+    ) -> Result<FiniteVector<D>, LaError> {
         let mut x = [0.0; D];
         let mut i = 0;
+        let b = b.into_array();
         while i < D {
-            x[i] = b.data[self.piv[i]];
+            x[i] = b[self.piv[i]];
             i += 1;
         }
 
@@ -198,7 +214,7 @@ impl<const D: usize> Lu<D> {
             ii += 1;
         }
 
-        Ok(Vector::new(x))
+        Ok(FiniteVector::new_unchecked(Vector::new(x)))
     }
 
     /// Determinant of the original matrix.
@@ -402,7 +418,10 @@ mod tests {
     #[test]
     fn solve_1x1() {
         let a = Matrix::<1>::from_rows(black_box([[2.0]]));
-        let lu = (black_box(Lu::<1>::factor))(a, DEFAULT_PIVOT_TOL).unwrap();
+        let lu = FiniteMatrix::try_new(a)
+            .unwrap()
+            .lu(DEFAULT_PIVOT_TOL)
+            .unwrap();
 
         let b = Vector::<1>::new(black_box([6.0]));
         let solve_fn: fn(&Lu<1>, Vector<1>) -> Result<Vector<1>, LaError> =
@@ -417,7 +436,10 @@ mod tests {
     #[test]
     fn solve_2x2_basic() {
         let a = Matrix::<2>::from_rows(black_box([[1.0, 2.0], [3.0, 4.0]]));
-        let lu = (black_box(Lu::<2>::factor))(a, DEFAULT_PIVOT_TOL).unwrap();
+        let lu = FiniteMatrix::try_new(a)
+            .unwrap()
+            .lu(DEFAULT_PIVOT_TOL)
+            .unwrap();
         let b = Vector::<2>::new(black_box([5.0, 11.0]));
 
         let solve_fn: fn(&Lu<2>, Vector<2>) -> Result<Vector<2>, LaError> =

--- a/src/lu.rs
+++ b/src/lu.rs
@@ -113,14 +113,18 @@ impl<const D: usize> Lu<D> {
     /// Returns [`LaError::Singular`] if a diagonal entry of `U` satisfies `|u_ii| <= tol`, where
     /// `tol` is the tolerance that was used during factorization.
     ///
-    /// Returns [`LaError::NonFinite`] if NaN/∞ is detected. The `row`/`col` coordinates
-    /// follow the convention documented on [`LaError::NonFinite`]:
+    /// Returns [`LaError::NonFinite`] if NaN/∞ is detected. If
+    /// `FiniteVector::try_new(b)` rejects a non-finite RHS entry, the error uses
+    /// `row: None` and `col: i`, where `i` is the offending vector index. The
+    /// `row`/`col` coordinates follow the convention documented on
+    /// [`LaError::NonFinite`]:
     ///
     /// - `row: Some(i), col: i` — the stored `U` diagonal at `(i, i)` is non-finite
     ///   (only reachable via direct `Lu` construction; [`Matrix::lu`](crate::Matrix::lu)
     ///   rejects such factorizations).
-    /// - `row: None, col: i` — a computed intermediate (forward/back-substitution
-    ///   accumulator or the quotient `sum / diag`) overflowed to NaN/∞ at step `i`.
+    /// - `row: None, col: i` — either RHS entry `b[i]` is non-finite, or a
+    ///   computed intermediate (forward/back-substitution accumulator or the
+    ///   quotient `sum / diag`) overflowed to NaN/∞ at step `i`.
     #[inline]
     pub const fn solve_vec(&self, b: Vector<D>) -> Result<Vector<D>, LaError> {
         match FiniteVector::try_new(b) {
@@ -676,6 +680,24 @@ mod tests {
                         err,
                         LaError::NonFinite {
                             row: Some($d - 1),
+                            col: $d - 1,
+                        }
+                    );
+                }
+
+                /// `solve_vec` rejects raw non-finite right-hand sides before
+                /// entering the finite-RHS solve path.
+                #[test]
+                fn [<solve_vec_rejects_non_finite_rhs_ $d d>]() {
+                    let lu = Matrix::<$d>::identity().lu(DEFAULT_PIVOT_TOL).unwrap();
+                    let mut rhs = [1.0; $d];
+                    rhs[$d - 1] = f64::NAN;
+
+                    let err = lu.solve_vec(Vector::<$d>::new(rhs)).unwrap_err();
+                    assert_eq!(
+                        err,
+                        LaError::NonFinite {
+                            row: None,
                             col: $d - 1,
                         }
                     );

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -13,137 +13,402 @@ pub struct Matrix<const D: usize> {
     pub(crate) rows: [[f64; D]; D],
 }
 
-/// Matrix proven symmetric under the crate's LDLT symmetry tolerance.
+/// Fixed-size square matrix whose stored entries are all finite.
 ///
-/// This wrapper carries the result of LDLT symmetry validation so callers can
-/// validate a raw [`Matrix`] once and then factor it without rediscovering that
-/// particular invariant.  It does not prove positive definiteness, finite
-/// arithmetic throughout factorization, or non-singularity; [`ldlt`](Self::ldlt)
-/// still validates those properties and returns the corresponding [`LaError`].
-///
-/// # Examples
-/// ```
-/// use la_stack::prelude::*;
-///
-/// # fn main() -> Result<(), LaError> {
-/// let a = Matrix::<2>::from_rows([[4.0, 2.0], [2.0, 3.0]]);
-/// let symmetric = SymmetricMatrix::try_new(a)?;
-/// let ldlt = symmetric.ldlt(DEFAULT_SINGULAR_TOL)?;
-///
-/// assert!((ldlt.det()? - 8.0).abs() <= 1e-12);
-/// # Ok(())
-/// # }
-/// ```
+/// This proof-carrying wrapper lets callers validate raw [`Matrix`] values once
+/// at an input boundary, then pass the finite invariant into numerical
+/// algorithms without repeatedly checking stored entries for NaN or infinity.
 #[must_use]
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub struct SymmetricMatrix<const D: usize> {
+#[allow(clippy::redundant_pub_crate)]
+pub(crate) struct FiniteMatrix<const D: usize> {
     matrix: Matrix<D>,
 }
 
-impl<const D: usize> SymmetricMatrix<D> {
-    /// Validate that `matrix` is symmetric under the LDLT symmetry tolerance.
+impl<const D: usize> FiniteMatrix<D> {
+    /// Construct a finite matrix without checking the invariant.
     ///
-    /// The predicate is the same one used by [`Matrix::ldlt`]:
-    /// `|A[i][j] - A[j][i]| <= 1e-12 * max(1, inf_norm(A))`, with scaling that
-    /// preserves strict tolerances when an unscaled row sum would overflow.
-    ///
-    /// # Examples
-    /// ```
-    /// use la_stack::prelude::*;
-    ///
-    /// # fn main() -> Result<(), LaError> {
-    /// let a = Matrix::<2>::from_rows([[4.0, 2.0], [2.0, 3.0]]);
-    /// let symmetric = SymmetricMatrix::try_new(a)?;
-    /// assert_eq!(symmetric.as_matrix().get(0, 1), Some(2.0));
-    /// # Ok(())
-    /// # }
-    /// ```
-    ///
-    /// # Errors
-    /// Returns [`LaError::Asymmetric`] when the first off-diagonal pair violates
-    /// the LDLT symmetry predicate.
-    ///
-    /// Returns [`LaError::NonFinite`] when any matrix entry is NaN or infinite,
-    /// or when computing the scaled symmetry tolerance overflows to NaN or
-    /// infinity.
+    /// This is crate-internal so public callers must use [`try_new`](Self::try_new)
+    /// or [`from_rows`](Self::from_rows), which preserve diagnostics for rejected
+    /// raw entries.
     #[inline]
-    pub fn try_new(matrix: Matrix<D>) -> Result<Self, LaError> {
-        if let Some((row, col)) = matrix.first_asymmetry(LDLT_SYMMETRY_REL_TOL)? {
-            cold_path();
-            Err(LaError::asymmetric(row, col, D))
+    pub(crate) const fn new_unchecked(matrix: Matrix<D>) -> Self {
+        Self { matrix }
+    }
+
+    /// Validate that every stored matrix entry is finite.
+    /// # Errors
+    /// Returns [`LaError::NonFinite`] with matrix coordinates for the first
+    /// offending entry in row-major order when `matrix` contains NaN or infinity.
+    #[inline]
+    pub const fn try_new(matrix: Matrix<D>) -> Result<Self, LaError> {
+        if let Some((row, col)) = matrix.first_non_finite_cell() {
+            Err(LaError::non_finite_cell(row, col))
         } else {
-            Ok(Self { matrix })
+            Ok(Self::new_unchecked(matrix))
         }
     }
 
-    /// Borrow the proven-symmetric matrix.
-    ///
-    /// # Examples
-    /// ```
-    /// use la_stack::prelude::*;
-    ///
-    /// # fn main() -> Result<(), LaError> {
-    /// let symmetric = SymmetricMatrix::try_new(Matrix::<2>::identity())?;
-    /// assert_eq!(symmetric.as_matrix().get(1, 1), Some(1.0));
-    /// # Ok(())
-    /// # }
-    /// ```
+    /// Validate raw row-major storage and construct a finite matrix.
+    /// # Errors
+    /// Returns [`LaError::NonFinite`] with matrix coordinates for the first
+    /// offending entry in row-major order when `rows` contains NaN or infinity.
     #[inline]
-    pub const fn as_matrix(&self) -> &Matrix<D> {
-        &self.matrix
+    pub const fn from_rows(rows: [[f64; D]; D]) -> Result<Self, LaError> {
+        Self::try_new(Matrix::from_rows(rows))
     }
 
-    /// Consume the wrapper and return the underlying matrix.
-    ///
-    /// # Examples
-    /// ```
-    /// use la_stack::prelude::*;
-    ///
-    /// # fn main() -> Result<(), LaError> {
-    /// let symmetric = SymmetricMatrix::try_new(Matrix::<2>::identity())?;
-    /// let matrix = symmetric.into_matrix();
-    /// assert_eq!(matrix.get(0, 0), Some(1.0));
-    /// # Ok(())
-    /// # }
-    /// ```
+    /// All-zeros finite matrix.
+    #[inline]
+    pub const fn zero() -> Self {
+        Self::new_unchecked(Matrix::zero())
+    }
+
+    /// Consume the wrapper and return the underlying raw matrix.
     #[inline]
     pub const fn into_matrix(self) -> Matrix<D> {
         self.matrix
     }
 
-    /// Compute an LDLT factorization from a matrix with a carried symmetry proof.
+    /// Borrow the underlying raw matrix without revalidating stored entries.
+    #[cfg(feature = "exact")]
+    #[inline]
+    pub(crate) const fn as_matrix(&self) -> &Matrix<D> {
+        &self.matrix
+    }
+
+    /// Infinity norm (maximum absolute row sum) for a finite matrix.
     ///
-    /// This skips the symmetry check already performed by [`try_new`](Self::try_new),
-    /// but still validates finite factorization intermediates and diagonal
-    /// singularity under `tol`.
-    ///
-    /// # Examples
-    /// ```
-    /// use la_stack::prelude::*;
-    ///
-    /// # fn main() -> Result<(), LaError> {
-    /// let a = Matrix::<2>::from_rows([[4.0, 2.0], [2.0, 3.0]]);
-    /// let ldlt = SymmetricMatrix::try_new(a)?.ldlt(DEFAULT_SINGULAR_TOL)?;
-    /// assert!((ldlt.det()? - 8.0).abs() <= 1e-12);
-    /// # Ok(())
-    /// # }
-    /// ```
+    /// Stored entries are known finite, so this path only checks whether a row
+    /// sum overflows to NaN or infinity.
     ///
     /// # Errors
-    /// Returns [`LaError::Singular`] if, for some step `k`, the required
-    /// diagonal entry `d = D[k,k]` is `<= tol` (non-positive or too small).
+    /// Returns [`LaError::NonFinite`] when a row sum overflows to NaN or infinity.
+    #[inline]
+    pub const fn inf_norm(&self) -> Result<f64, LaError> {
+        let mut max_row_sum: f64 = 0.0;
+
+        let mut r = 0;
+        while r < D {
+            let row = &self.matrix.rows[r];
+            let mut row_sum: f64 = 0.0;
+            let mut c = 0;
+            while c < D {
+                row_sum += row[c].abs();
+                c += 1;
+            }
+            if !row_sum.is_finite() {
+                cold_path();
+                return Err(LaError::non_finite_at(r));
+            }
+            if row_sum > max_row_sum {
+                max_row_sum = row_sum;
+            }
+            r += 1;
+        }
+
+        Ok(max_row_sum)
+    }
+
+    /// Returns `true` if the finite matrix is symmetric within a relative tolerance.
     ///
-    /// Returns [`LaError::NonFinite`] if NaN/∞ is detected during factorization.
+    /// # Errors
+    /// Returns [`LaError::NonFinite`] when computing the scaled symmetry tolerance
+    /// overflows to NaN or infinity.
+    #[inline]
+    pub fn is_symmetric(&self, rel_tol: Tolerance) -> Result<bool, LaError> {
+        Ok(self.first_asymmetry(rel_tol)?.is_none())
+    }
+
+    /// Returns the first asymmetric off-diagonal pair, if any.
+    ///
+    /// # Errors
+    /// Returns [`LaError::NonFinite`] when computing the scaled symmetry tolerance
+    /// overflows to NaN or infinity.
+    #[inline]
+    pub fn first_asymmetry(&self, rel_tol: Tolerance) -> Result<Option<(usize, usize)>, LaError> {
+        let eps = self.symmetry_epsilon(rel_tol)?;
+        for r in 0..D {
+            for c in (r + 1)..D {
+                let upper = self.matrix.rows[r][c];
+                let lower = self.matrix.rows[c][r];
+
+                let diff = (upper - lower).abs();
+                if !diff.is_finite() || diff > eps {
+                    cold_path();
+                    return Ok(Some((r, c)));
+                }
+            }
+        }
+        Ok(None)
+    }
+
+    /// Compute the symmetry tolerance scale for a finite matrix.
+    fn symmetry_epsilon(&self, rel_tol: Tolerance) -> Result<f64, LaError> {
+        let rel_tol = rel_tol.get();
+        let mut eps = rel_tol;
+
+        for r in 0..D {
+            let mut row_eps = 0.0;
+            for c in 0..D {
+                row_eps = rel_tol.mul_add(self.matrix.rows[r][c].abs(), row_eps);
+                if !row_eps.is_finite() {
+                    cold_path();
+                    return Err(LaError::non_finite_at(c));
+                }
+            }
+            if row_eps > eps {
+                eps = row_eps;
+            }
+        }
+
+        Ok(eps)
+    }
+
+    /// Compute an LU decomposition with partial pivoting.
+    ///
+    /// # Errors
+    /// Returns [`LaError::Singular`] for an unusable pivot, or
+    /// [`LaError::NonFinite`] if elimination computes a non-finite intermediate.
+    #[inline]
+    pub fn lu(self, tol: Tolerance) -> Result<Lu<D>, LaError> {
+        Lu::factor_finite(self, tol)
+    }
+
+    /// Compute an LDLT factorization (`A = L D Lᵀ`) without pivoting.
+    ///
+    /// # Errors
+    /// Returns [`LaError::Asymmetric`] if the matrix is not symmetric,
+    /// [`LaError::NotPositiveSemidefinite`] for a negative LDLT diagonal,
+    /// [`LaError::Singular`] for a zero or too-small non-negative diagonal, or
+    /// [`LaError::NonFinite`] if factorization computes a non-finite intermediate.
     #[inline]
     pub fn ldlt(self, tol: Tolerance) -> Result<Ldlt<D>, LaError> {
-        Ldlt::factor_symmetric(self.matrix, tol)
+        Ldlt::factor_symmetric(SymmetricMatrix::try_new(self)?, tol)
+    }
+
+    /// Closed-form determinant for dimensions 0–4, bypassing LU factorization.
+    ///
+    /// # Errors
+    /// Returns [`LaError::NonFinite`] when the closed-form determinant overflows
+    /// to NaN or infinity.
+    #[inline]
+    pub const fn det_direct(&self) -> Result<Option<f64>, LaError> {
+        match D {
+            0 => Ok(Some(1.0)),
+            1 => Self::computed_scalar_result(Some(self.matrix.rows[0][0])),
+            2 => Self::computed_scalar_result(Some(self.matrix.rows[0][0].mul_add(
+                self.matrix.rows[1][1],
+                -(self.matrix.rows[0][1] * self.matrix.rows[1][0]),
+            ))),
+            3 => {
+                let m00 = self.matrix.rows[1][1].mul_add(
+                    self.matrix.rows[2][2],
+                    -(self.matrix.rows[1][2] * self.matrix.rows[2][1]),
+                );
+                let m01 = self.matrix.rows[1][0].mul_add(
+                    self.matrix.rows[2][2],
+                    -(self.matrix.rows[1][2] * self.matrix.rows[2][0]),
+                );
+                let m02 = self.matrix.rows[1][0].mul_add(
+                    self.matrix.rows[2][1],
+                    -(self.matrix.rows[1][1] * self.matrix.rows[2][0]),
+                );
+                Self::computed_scalar_result(Some(self.matrix.rows[0][0].mul_add(
+                    m00,
+                    (-self.matrix.rows[0][1]).mul_add(m01, self.matrix.rows[0][2] * m02),
+                )))
+            }
+            4 => {
+                let r = &self.matrix.rows;
+
+                let s23 = r[2][2].mul_add(r[3][3], -(r[2][3] * r[3][2]));
+                let s13 = r[2][1].mul_add(r[3][3], -(r[2][3] * r[3][1]));
+                let s12 = r[2][1].mul_add(r[3][2], -(r[2][2] * r[3][1]));
+                let s03 = r[2][0].mul_add(r[3][3], -(r[2][3] * r[3][0]));
+                let s02 = r[2][0].mul_add(r[3][2], -(r[2][2] * r[3][0]));
+                let s01 = r[2][0].mul_add(r[3][1], -(r[2][1] * r[3][0]));
+
+                let c00 = r[1][1].mul_add(s23, (-r[1][2]).mul_add(s13, r[1][3] * s12));
+                let c01 = r[1][0].mul_add(s23, (-r[1][2]).mul_add(s03, r[1][3] * s02));
+                let c02 = r[1][0].mul_add(s13, (-r[1][1]).mul_add(s03, r[1][3] * s01));
+                let c03 = r[1][0].mul_add(s12, (-r[1][1]).mul_add(s02, r[1][2] * s01));
+
+                Self::computed_scalar_result(Some(r[0][0].mul_add(
+                    c00,
+                    (-r[0][1]).mul_add(c01, r[0][2].mul_add(c02, -(r[0][3] * c03))),
+                )))
+            }
+            _ => {
+                cold_path();
+                Ok(None)
+            }
+        }
+    }
+
+    /// Floating-point determinant for a finite matrix.
+    ///
+    /// # Errors
+    /// Returns [`LaError::NonFinite`] if a computed determinant or LU fallback
+    /// intermediate overflows to NaN or infinity.
+    #[inline]
+    pub fn det(self) -> Result<f64, LaError> {
+        if let Some(d) = self.det_direct()? {
+            return Ok(d);
+        }
+        match self.lu(Tolerance::new_unchecked(0.0)) {
+            Ok(lu) => lu.det(),
+            Err(LaError::Singular { .. }) => Ok(0.0),
+            Err(err) => Err(err),
+        }
+    }
+
+    /// Conservative absolute error bound for [`det_direct`](Self::det_direct).
+    ///
+    /// # Errors
+    /// Returns [`LaError::NonFinite`] when the bound computation overflows to NaN
+    /// or infinity.
+    #[inline]
+    pub const fn det_errbound(&self) -> Result<Option<f64>, LaError> {
+        match D {
+            0 | 1 => Self::computed_scalar_result(Some(0.0)),
+            2 => {
+                let r = &self.matrix.rows;
+                let permanent = (r[0][0] * r[1][1]).abs() + (r[0][1] * r[1][0]).abs();
+                Self::computed_scalar_result(Some(ERR_COEFF_2 * permanent))
+            }
+            3 => {
+                let r = &self.matrix.rows;
+                let pm00 = (r[1][1] * r[2][2]).abs() + (r[1][2] * r[2][1]).abs();
+                let pm01 = (r[1][0] * r[2][2]).abs() + (r[1][2] * r[2][0]).abs();
+                let pm02 = (r[1][0] * r[2][1]).abs() + (r[1][1] * r[2][0]).abs();
+                let permanent = r[0][2]
+                    .abs()
+                    .mul_add(pm02, r[0][1].abs().mul_add(pm01, r[0][0].abs() * pm00));
+                Self::computed_scalar_result(Some(ERR_COEFF_3 * permanent))
+            }
+            4 => {
+                let r = &self.matrix.rows;
+                let sp23 = (r[2][2] * r[3][3]).abs() + (r[2][3] * r[3][2]).abs();
+                let sp13 = (r[2][1] * r[3][3]).abs() + (r[2][3] * r[3][1]).abs();
+                let sp12 = (r[2][1] * r[3][2]).abs() + (r[2][2] * r[3][1]).abs();
+                let sp03 = (r[2][0] * r[3][3]).abs() + (r[2][3] * r[3][0]).abs();
+                let sp02 = (r[2][0] * r[3][2]).abs() + (r[2][2] * r[3][0]).abs();
+                let sp01 = (r[2][0] * r[3][1]).abs() + (r[2][1] * r[3][0]).abs();
+                let pc0 = r[1][3]
+                    .abs()
+                    .mul_add(sp12, r[1][2].abs().mul_add(sp13, r[1][1].abs() * sp23));
+                let pc1 = r[1][3]
+                    .abs()
+                    .mul_add(sp02, r[1][2].abs().mul_add(sp03, r[1][0].abs() * sp23));
+                let pc2 = r[1][3]
+                    .abs()
+                    .mul_add(sp01, r[1][1].abs().mul_add(sp03, r[1][0].abs() * sp13));
+                let pc3 = r[1][2]
+                    .abs()
+                    .mul_add(sp01, r[1][1].abs().mul_add(sp02, r[1][0].abs() * sp12));
+                let permanent = r[0][3].abs().mul_add(
+                    pc3,
+                    r[0][2]
+                        .abs()
+                        .mul_add(pc2, r[0][1].abs().mul_add(pc1, r[0][0].abs() * pc0)),
+                );
+                Self::computed_scalar_result(Some(ERR_COEFF_4 * permanent))
+            }
+            _ => {
+                cold_path();
+                Ok(None)
+            }
+        }
+    }
+
+    /// Return a computed scalar result for a matrix with finite stored entries.
+    const fn computed_scalar_result(value: Option<f64>) -> Result<Option<f64>, LaError> {
+        match value {
+            Some(value) if value.is_finite() => Ok(Some(value)),
+            Some(_) => Err(LaError::non_finite_at(0)),
+            None => Ok(None),
+        }
     }
 }
 
-impl<const D: usize> From<SymmetricMatrix<D>> for Matrix<D> {
+impl<const D: usize> Default for FiniteMatrix<D> {
     #[inline]
-    fn from(value: SymmetricMatrix<D>) -> Self {
+    fn default() -> Self {
+        Self::zero()
+    }
+}
+
+impl<const D: usize> From<FiniteMatrix<D>> for Matrix<D> {
+    #[inline]
+    fn from(value: FiniteMatrix<D>) -> Self {
         value.into_matrix()
+    }
+}
+
+impl<const D: usize> TryFrom<Matrix<D>> for FiniteMatrix<D> {
+    type Error = LaError;
+
+    #[inline]
+    fn try_from(value: Matrix<D>) -> Result<Self, Self::Error> {
+        Self::try_new(value)
+    }
+}
+
+impl<const D: usize> TryFrom<[[f64; D]; D]> for FiniteMatrix<D> {
+    type Error = LaError;
+
+    #[inline]
+    fn try_from(value: [[f64; D]; D]) -> Result<Self, Self::Error> {
+        Self::from_rows(value)
+    }
+}
+
+/// Matrix proven finite and symmetric under the crate's LDLT symmetry tolerance.
+#[must_use]
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[allow(clippy::redundant_pub_crate)]
+pub(crate) struct SymmetricMatrix<const D: usize> {
+    matrix: Matrix<D>,
+}
+
+impl<const D: usize> SymmetricMatrix<D> {
+    /// Construct a symmetric matrix proof without checking the invariant.
+    ///
+    /// This constructor is only for paths that have already validated finite
+    /// entries and LDLT symmetry with the same predicate as
+    /// [`try_new`](Self::try_new).
+    #[inline]
+    pub(crate) const fn new_unchecked(matrix: Matrix<D>) -> Self {
+        Self { matrix }
+    }
+
+    /// Validate that a finite matrix is symmetric under the LDLT symmetry tolerance.
+    ///
+    /// The predicate is the same one used by [`Matrix::ldlt`]:
+    /// `|A[i][j] - A[j][i]| <= 1e-12 * max(1, inf_norm(A))`, with scaling that
+    /// preserves strict tolerances when an unscaled row sum would overflow.
+    ///
+    /// # Errors
+    /// Returns [`LaError::Asymmetric`] when the first off-diagonal pair violates
+    /// the LDLT symmetry predicate.
+    ///
+    /// Returns [`LaError::NonFinite`] when computing the scaled symmetry
+    /// tolerance overflows to NaN or infinity.
+    #[inline]
+    pub(crate) fn try_new(matrix: FiniteMatrix<D>) -> Result<Self, LaError> {
+        if let Some((row, col)) = matrix.first_asymmetry(LDLT_SYMMETRY_REL_TOL)? {
+            cold_path();
+            Err(LaError::asymmetric(row, col, D))
+        } else {
+            Ok(Self::new_unchecked(matrix.into_matrix()))
+        }
+    }
+
+    /// Consume the wrapper and return the underlying matrix.
+    #[inline]
+    pub(crate) const fn into_matrix(self) -> Matrix<D> {
+        self.matrix
     }
 }
 
@@ -358,35 +623,10 @@ impl<const D: usize> Matrix<D> {
     /// a row sum overflows to NaN or infinity.
     #[inline]
     pub const fn inf_norm(&self) -> Result<f64, LaError> {
-        let mut max_row_sum: f64 = 0.0;
-
-        let mut r = 0;
-        while r < D {
-            // Iterator chains like `row.iter().map(|x| x.abs()).sum()` are
-            // not yet const-stable, so accumulate the absolute row sum with
-            // a manual `while` loop.
-            let row = &self.rows[r];
-            let mut row_sum: f64 = 0.0;
-            let mut c = 0;
-            while c < D {
-                if !row[c].is_finite() {
-                    cold_path();
-                    return Err(LaError::non_finite_cell(r, c));
-                }
-                row_sum += row[c].abs();
-                c += 1;
-            }
-            if !row_sum.is_finite() {
-                cold_path();
-                return Err(LaError::non_finite_at(r));
-            }
-            if row_sum > max_row_sum {
-                max_row_sum = row_sum;
-            }
-            r += 1;
+        match FiniteMatrix::try_new(*self) {
+            Ok(finite) => finite.inf_norm(),
+            Err(err) => Err(err),
         }
-
-        Ok(max_row_sum)
     }
 
     /// Returns `true` if the matrix is symmetric within a relative tolerance.
@@ -434,7 +674,7 @@ impl<const D: usize> Matrix<D> {
     /// infinity.
     #[inline]
     pub fn is_symmetric(&self, rel_tol: Tolerance) -> Result<bool, LaError> {
-        Ok(self.first_asymmetry(rel_tol)?.is_none())
+        FiniteMatrix::try_new(*self)?.is_symmetric(rel_tol)
     }
 
     /// Returns the indices `(r, c)` (with `r < c`) of the first off-diagonal
@@ -481,64 +721,7 @@ impl<const D: usize> Matrix<D> {
     /// infinity.
     #[inline]
     pub fn first_asymmetry(&self, rel_tol: Tolerance) -> Result<Option<(usize, usize)>, LaError> {
-        let eps = self.symmetry_epsilon(rel_tol)?;
-        for r in 0..D {
-            for c in (r + 1)..D {
-                let upper = self.rows[r][c];
-                let lower = self.rows[c][r];
-
-                let diff = (upper - lower).abs();
-                // Finite stored entries can still produce an infinite
-                // difference when the subtraction overflows.  That is an
-                // asymmetry, not a stored non-finite matrix value.
-                if !diff.is_finite() || diff > eps {
-                    cold_path();
-                    return Ok(Some((r, c)));
-                }
-            }
-        }
-        Ok(None)
-    }
-
-    /// Compute the symmetry tolerance scale used by [`first_asymmetry`](Self::first_asymmetry).
-    ///
-    /// The result is equivalent to `rel_tol * max(1, inf_norm())`, but the
-    /// accumulation scales each absolute entry before adding it.  That preserves
-    /// strict tolerances even when the unscaled row sum would overflow.
-    ///
-    /// This also validates every stored entry before symmetry comparison.
-    /// Otherwise a non-finite diagonal, or a finite row whose unscaled sum
-    /// overflows, can make the symmetry threshold NaN/∞ and mask real
-    /// off-diagonal mismatches.
-    ///
-    /// # Errors
-    /// Returns [`LaError::NonFinite`] when any matrix entry is NaN or infinite,
-    /// or when computing the scaled symmetry tolerance overflows to NaN or
-    /// infinity.
-    fn symmetry_epsilon(&self, rel_tol: Tolerance) -> Result<f64, LaError> {
-        let rel_tol = rel_tol.get();
-        let mut eps = rel_tol;
-
-        for r in 0..D {
-            let mut row_eps = 0.0;
-            for c in 0..D {
-                let entry = self.rows[r][c];
-                if !entry.is_finite() {
-                    cold_path();
-                    return Err(LaError::non_finite_cell(r, c));
-                }
-                row_eps = rel_tol.mul_add(entry.abs(), row_eps);
-                if !row_eps.is_finite() {
-                    cold_path();
-                    return Err(LaError::non_finite_at(c));
-                }
-            }
-            if row_eps > eps {
-                eps = row_eps;
-            }
-        }
-
-        Ok(eps)
+        FiniteMatrix::try_new(*self)?.first_asymmetry(rel_tol)
     }
 
     /// Compute an LU decomposition with partial pivoting.
@@ -574,7 +757,7 @@ impl<const D: usize> Matrix<D> {
     /// the returned [`Lu`].
     #[inline]
     pub fn lu(self, tol: Tolerance) -> Result<Lu<D>, LaError> {
-        Lu::factor(self, tol)
+        FiniteMatrix::try_new(self)?.lu(tol)
     }
 
     /// Compute an LDLT factorization (`A = L D Lᵀ`) without pivoting.
@@ -619,14 +802,15 @@ impl<const D: usize> Matrix<D> {
     /// ```
     ///
     /// # Errors
-    /// Returns [`LaError::Singular`] if, for some step `k`, the required diagonal entry `d = D[k,k]`
-    /// is `<= tol` (non-positive or too small). This treats PSD degeneracy (and indefinite inputs)
+    /// Returns [`LaError::NotPositiveSemidefinite`] if, for some step `k`, the required
+    /// diagonal entry `d = D[k,k]` is negative.
+    /// Returns [`LaError::Singular`] if `0 <= d <= tol`, treating PSD degeneracy
     /// as singular/degenerate.
     /// Returns [`LaError::NonFinite`] if NaN/∞ is detected during factorization.
     /// Returns [`LaError::Asymmetric`] if the input matrix is not symmetric.
     #[inline]
     pub fn ldlt(self, tol: Tolerance) -> Result<Ldlt<D>, LaError> {
-        Ldlt::factor(self, tol)
+        FiniteMatrix::try_new(self)?.ldlt(tol)
     }
 
     /// Return the first non-finite stored cell in row-major order.
@@ -643,19 +827,6 @@ impl<const D: usize> Matrix<D> {
             r += 1;
         }
         None
-    }
-
-    /// Return a computed scalar result, preserving non-finite diagnostics.
-    const fn computed_scalar_result(&self, value: Option<f64>) -> Result<Option<f64>, LaError> {
-        if let Some((row, col)) = self.first_non_finite_cell() {
-            Err(LaError::non_finite_cell(row, col))
-        } else {
-            match value {
-                Some(value) if value.is_finite() => Ok(Some(value)),
-                Some(_) => Err(LaError::non_finite_at(0)),
-                None => Ok(None),
-            }
-        }
     }
 
     /// Closed-form determinant for dimensions 0–4, bypassing LU factorization.
@@ -690,57 +861,9 @@ impl<const D: usize> Matrix<D> {
     /// the closed-form determinant overflows to NaN or infinity.
     #[inline]
     pub const fn det_direct(&self) -> Result<Option<f64>, LaError> {
-        match D {
-            0 => Ok(Some(1.0)),
-            1 => self.computed_scalar_result(Some(self.rows[0][0])),
-            2 => {
-                // ad - bc
-                self.computed_scalar_result(Some(
-                    self.rows[0][0].mul_add(self.rows[1][1], -(self.rows[0][1] * self.rows[1][0])),
-                ))
-            }
-            3 => {
-                // Cofactor expansion on first row.
-                let m00 =
-                    self.rows[1][1].mul_add(self.rows[2][2], -(self.rows[1][2] * self.rows[2][1]));
-                let m01 =
-                    self.rows[1][0].mul_add(self.rows[2][2], -(self.rows[1][2] * self.rows[2][0]));
-                let m02 =
-                    self.rows[1][0].mul_add(self.rows[2][1], -(self.rows[1][1] * self.rows[2][0]));
-                self.computed_scalar_result(Some(
-                    self.rows[0][0]
-                        .mul_add(m00, (-self.rows[0][1]).mul_add(m01, self.rows[0][2] * m02)),
-                ))
-            }
-            4 => {
-                // Cofactor expansion on first row → four 3×3 sub-determinants.
-                // Hoist the 6 unique 2×2 minors from rows 2–3 (each used twice).
-                let r = &self.rows;
-
-                // 2×2 minors: s_ij = r[2][i]*r[3][j] - r[2][j]*r[3][i]
-                let s23 = r[2][2].mul_add(r[3][3], -(r[2][3] * r[3][2])); // cols 2,3
-                let s13 = r[2][1].mul_add(r[3][3], -(r[2][3] * r[3][1])); // cols 1,3
-                let s12 = r[2][1].mul_add(r[3][2], -(r[2][2] * r[3][1])); // cols 1,2
-                let s03 = r[2][0].mul_add(r[3][3], -(r[2][3] * r[3][0])); // cols 0,3
-                let s02 = r[2][0].mul_add(r[3][2], -(r[2][2] * r[3][0])); // cols 0,2
-                let s01 = r[2][0].mul_add(r[3][1], -(r[2][1] * r[3][0])); // cols 0,1
-
-                // 3×3 cofactors via row 1 expansion using hoisted minors.
-                let c00 = r[1][1].mul_add(s23, (-r[1][2]).mul_add(s13, r[1][3] * s12));
-                let c01 = r[1][0].mul_add(s23, (-r[1][2]).mul_add(s03, r[1][3] * s02));
-                let c02 = r[1][0].mul_add(s13, (-r[1][1]).mul_add(s03, r[1][3] * s01));
-                let c03 = r[1][0].mul_add(s12, (-r[1][1]).mul_add(s02, r[1][2] * s01));
-
-                self.computed_scalar_result(Some(r[0][0].mul_add(
-                    c00,
-                    (-r[0][1]).mul_add(c01, r[0][2].mul_add(c02, -(r[0][3] * c03))),
-                )))
-            }
-            _ => {
-                // Cold in the common D ≤ 4 case; callers fall back to LU for D ≥ 5.
-                cold_path();
-                self.computed_scalar_result(None)
-            }
+        match FiniteMatrix::try_new(*self) {
+            Ok(finite) => finite.det_direct(),
+            Err(err) => Err(err),
         }
     }
 
@@ -777,14 +900,7 @@ impl<const D: usize> Matrix<D> {
     /// product overflows to NaN or infinity.
     #[inline]
     pub fn det(self) -> Result<f64, LaError> {
-        if let Some(d) = self.det_direct()? {
-            return Ok(d);
-        }
-        match self.lu(Tolerance::new_unchecked(0.0)) {
-            Ok(lu) => lu.det(),
-            Err(LaError::Singular { .. }) => Ok(0.0),
-            Err(err) => Err(err),
-        }
+        FiniteMatrix::try_new(self)?.det()
     }
 
     /// Conservative absolute error bound for `det_direct()`.
@@ -794,9 +910,8 @@ impl<const D: usize> Matrix<D> {
     ///
     /// For D ≤ 4, the bound is derived from the absolute Leibniz sum using
     /// Shewchuk-style error analysis (see `REFERENCES.md` \[8\] and the
-    /// per-constant docs on [`ERR_COEFF_2`](crate::ERR_COEFF_2),
-    /// [`ERR_COEFF_3`](crate::ERR_COEFF_3), and
-    /// [`ERR_COEFF_4`](crate::ERR_COEFF_4)). For D = 0 or 1, returns
+    /// per-constant docs on [`ERR_COEFF_2`], [`ERR_COEFF_3`], and
+    /// [`ERR_COEFF_4`]). For D = 0 or 1, returns
     /// `Some(0.0)` since the determinant computation is exact (no
     /// arithmetic).
     ///
@@ -853,57 +968,9 @@ impl<const D: usize> Matrix<D> {
     /// the bound computation overflows to NaN or infinity.
     #[inline]
     pub const fn det_errbound(&self) -> Result<Option<f64>, LaError> {
-        match D {
-            0 | 1 => self.computed_scalar_result(Some(0.0)), // No arithmetic — result is exact.
-            2 => {
-                let r = &self.rows;
-                let permanent = (r[0][0] * r[1][1]).abs() + (r[0][1] * r[1][0]).abs();
-                self.computed_scalar_result(Some(ERR_COEFF_2 * permanent))
-            }
-            3 => {
-                let r = &self.rows;
-                let pm00 = (r[1][1] * r[2][2]).abs() + (r[1][2] * r[2][1]).abs();
-                let pm01 = (r[1][0] * r[2][2]).abs() + (r[1][2] * r[2][0]).abs();
-                let pm02 = (r[1][0] * r[2][1]).abs() + (r[1][1] * r[2][0]).abs();
-                let permanent = r[0][2]
-                    .abs()
-                    .mul_add(pm02, r[0][1].abs().mul_add(pm01, r[0][0].abs() * pm00));
-                self.computed_scalar_result(Some(ERR_COEFF_3 * permanent))
-            }
-            4 => {
-                let r = &self.rows;
-                // 2×2 minor permanents from rows 2–3.
-                let sp23 = (r[2][2] * r[3][3]).abs() + (r[2][3] * r[3][2]).abs();
-                let sp13 = (r[2][1] * r[3][3]).abs() + (r[2][3] * r[3][1]).abs();
-                let sp12 = (r[2][1] * r[3][2]).abs() + (r[2][2] * r[3][1]).abs();
-                let sp03 = (r[2][0] * r[3][3]).abs() + (r[2][3] * r[3][0]).abs();
-                let sp02 = (r[2][0] * r[3][2]).abs() + (r[2][2] * r[3][0]).abs();
-                let sp01 = (r[2][0] * r[3][1]).abs() + (r[2][1] * r[3][0]).abs();
-                // 3×3 cofactor permanents from row 1.
-                let pc0 = r[1][3]
-                    .abs()
-                    .mul_add(sp12, r[1][2].abs().mul_add(sp13, r[1][1].abs() * sp23));
-                let pc1 = r[1][3]
-                    .abs()
-                    .mul_add(sp02, r[1][2].abs().mul_add(sp03, r[1][0].abs() * sp23));
-                let pc2 = r[1][3]
-                    .abs()
-                    .mul_add(sp01, r[1][1].abs().mul_add(sp03, r[1][0].abs() * sp13));
-                let pc3 = r[1][2]
-                    .abs()
-                    .mul_add(sp01, r[1][1].abs().mul_add(sp02, r[1][0].abs() * sp12));
-                let permanent = r[0][3].abs().mul_add(
-                    pc3,
-                    r[0][2]
-                        .abs()
-                        .mul_add(pc2, r[0][1].abs().mul_add(pc1, r[0][0].abs() * pc0)),
-                );
-                self.computed_scalar_result(Some(ERR_COEFF_4 * permanent))
-            }
-            _ => {
-                cold_path();
-                self.computed_scalar_result(None)
-            }
+        match FiniteMatrix::try_new(*self) {
+            Ok(finite) => finite.det_errbound(),
+            Err(err) => Err(err),
         }
     }
 }
@@ -918,12 +985,31 @@ impl<const D: usize> Default for Matrix<D> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{DEFAULT_PIVOT_TOL, Vector};
+    use crate::DEFAULT_PIVOT_TOL;
+    use crate::vector::{FiniteVector, Vector};
 
     use approx::assert_abs_diff_eq;
     use core::assert_matches;
     use pastey::paste;
     use std::hint::black_box;
+
+    fn assert_matrix_abs_eq<const D: usize>(actual: &Matrix<D>, expected: &Matrix<D>) {
+        for r in 0..D {
+            for c in 0..D {
+                assert_abs_diff_eq!(
+                    actual.get(r, c).unwrap(),
+                    expected.get(r, c).unwrap(),
+                    epsilon = 0.0
+                );
+            }
+        }
+    }
+
+    fn assert_array_abs_eq<const D: usize>(actual: &[f64; D], expected: &[f64; D]) {
+        for i in 0..D {
+            assert_abs_diff_eq!(actual[i], expected[i], epsilon = 0.0);
+        }
+    }
 
     macro_rules! gen_public_api_matrix_tests {
         ($d:literal) => {
@@ -1044,6 +1130,103 @@ mod tests {
                     for (x_i, b_i) in x.iter().zip(b_arr.iter()) {
                         assert_abs_diff_eq!(*x_i, *b_i, epsilon = 1e-12);
                     }
+                }
+
+                #[test]
+                fn [<finite_matrix_accepts_and_roundtrips_ $d d>]() {
+                    let mut rows = [[0.0f64; $d]; $d];
+                    for r in 0..$d {
+                        rows[r][r] = 1.0;
+                    }
+
+                    let finite = FiniteMatrix::<$d>::from_rows(rows).unwrap();
+
+                    assert_matrix_abs_eq(&finite.into_matrix(), &Matrix::<$d>::from_rows(rows));
+                    assert_eq!(finite.into_matrix().get(0, 0), Some(1.0));
+                    assert_eq!(finite.into_matrix().get($d, 0), None);
+                    assert_eq!(
+                        finite.into_matrix().get_checked($d, 0),
+                        Err(LaError::IndexOutOfBounds {
+                            row: $d,
+                            col: 0,
+                            dim: $d,
+                        })
+                    );
+                    assert_matrix_abs_eq(&Matrix::from(finite), &Matrix::<$d>::from_rows(rows));
+                    assert_matrix_abs_eq(
+                        &FiniteMatrix::<$d>::try_from(Matrix::<$d>::from_rows(rows))
+                            .unwrap()
+                            .into_matrix(),
+                        &finite.into_matrix()
+                    );
+                    assert_matrix_abs_eq(
+                        &FiniteMatrix::<$d>::try_from(rows).unwrap().into_matrix(),
+                        &finite.into_matrix()
+                    );
+                }
+
+                #[test]
+                fn [<finite_matrix_rejects_nonfinite_with_coordinates_ $d d>]() {
+                    let mut rows = [[1.0f64; $d]; $d];
+                    rows[$d - 1][0] = f64::NAN;
+
+                    assert_eq!(
+                        FiniteMatrix::<$d>::from_rows(rows),
+                        Err(LaError::NonFinite {
+                            row: Some($d - 1),
+                            col: 0,
+                        })
+                    );
+                }
+
+                #[test]
+                fn [<finite_matrix_algorithms_match_raw_boundary_ $d d>]() {
+                    let mut rows = [[0.0f64; $d]; $d];
+                    let diag_values = [2.0f64, 3.0, 5.0, 7.0, 11.0];
+                    for i in 0..$d {
+                        rows[i][i] = diag_values[i];
+                    }
+
+                    let raw = Matrix::<$d>::from_rows(rows);
+                    let finite = FiniteMatrix::<$d>::from_rows(rows).unwrap();
+
+                    assert_abs_diff_eq!(finite.inf_norm().unwrap(), raw.inf_norm().unwrap(), epsilon = 0.0);
+                    assert_eq!(finite.det_direct(), raw.det_direct());
+                    assert_abs_diff_eq!(finite.det().unwrap(), raw.det().unwrap(), epsilon = 0.0);
+                    assert_eq!(finite.det_errbound(), raw.det_errbound());
+                    assert_eq!(
+                        finite.first_asymmetry(Tolerance::new(1e-12).unwrap()).unwrap(),
+                        raw.first_asymmetry(Tolerance::new(1e-12).unwrap()).unwrap()
+                    );
+                    assert_eq!(
+                        finite.is_symmetric(Tolerance::new(1e-12).unwrap()).unwrap(),
+                        raw.is_symmetric(Tolerance::new(1e-12).unwrap()).unwrap()
+                    );
+                }
+
+                #[test]
+                fn [<finite_matrix_lu_and_ldlt_accept_finite_rhs_ $d d>]() {
+                    let finite = FiniteMatrix::<$d>::try_new(Matrix::<$d>::identity()).unwrap();
+                    let rhs = {
+                        let mut arr = [0.0f64; $d];
+                        let values = [1.0f64, 2.0, 3.0, 4.0, 5.0];
+                        for (dst, src) in arr.iter_mut().zip(values.iter()) {
+                            *dst = *src;
+                        }
+                        FiniteVector::<$d>::from_array(arr).unwrap()
+                    };
+
+                    let lu = finite.lu(DEFAULT_PIVOT_TOL).unwrap();
+                    assert_array_abs_eq(
+                        &lu.solve_finite_vec(rhs).unwrap().into_array(),
+                        &rhs.into_array()
+                    );
+
+                    let ldlt = finite.ldlt(DEFAULT_PIVOT_TOL).unwrap();
+                    assert_array_abs_eq(
+                        &ldlt.solve_finite_vec(rhs).unwrap().into_array(),
+                        &rhs.into_array()
+                    );
                 }
             }
         };
@@ -1385,6 +1568,28 @@ mod tests {
     }
 
     #[test]
+    fn det_errbound_matches_documented_coefficient_scale() {
+        let m2 = Matrix::<2>::from_rows([[1.0, 2.0], [3.0, 4.0]]);
+        let expected_2 = ERR_COEFF_2 * ((1.0_f64 * 4.0).abs() + (2.0_f64 * 3.0).abs());
+        assert_abs_diff_eq!(
+            m2.det_errbound().unwrap().unwrap(),
+            expected_2,
+            epsilon = 0.0
+        );
+
+        assert_abs_diff_eq!(
+            Matrix::<3>::identity().det_errbound().unwrap().unwrap(),
+            ERR_COEFF_3,
+            epsilon = 0.0
+        );
+        assert_abs_diff_eq!(
+            Matrix::<4>::identity().det_errbound().unwrap().unwrap(),
+            ERR_COEFF_4,
+            epsilon = 0.0
+        );
+    }
+
+    #[test]
     fn det_errbound_d5_returns_none() {
         // D=5 has no fast filter
         assert_eq!(Matrix::<5>::identity().det_errbound(), Ok(None));
@@ -1639,18 +1844,17 @@ mod tests {
     gen_is_symmetric_tests!(4);
     gen_is_symmetric_tests!(5);
 
-    macro_rules! gen_symmetric_matrix_tests {
+    macro_rules! gen_ldlt_symmetry_proof_tests {
         ($d:literal) => {
             paste! {
                 #[test]
-                fn [<symmetric_matrix_try_new_accepts_identity_and_ldlt_ $d d>]() {
-                    let symmetric = SymmetricMatrix::try_new(Matrix::<$d>::identity()).unwrap();
-                    let ldlt = symmetric.ldlt(DEFAULT_PIVOT_TOL).unwrap();
+                fn [<matrix_ldlt_accepts_identity_ $d d>]() {
+                    let ldlt = Matrix::<$d>::identity().ldlt(DEFAULT_PIVOT_TOL).unwrap();
                     assert_abs_diff_eq!(ldlt.det().unwrap(), 1.0, epsilon = 0.0);
                 }
 
                 #[test]
-                fn [<symmetric_matrix_try_new_rejects_asymmetric_ $d d>]() {
+                fn [<symmetric_matrix_try_new_rejects_finite_asymmetric_ $d d>]() {
                     let mut rows = [[0.0f64; $d]; $d];
                     for (i, row) in rows.iter_mut().enumerate() {
                         row[i] = 1.0;
@@ -1659,7 +1863,7 @@ mod tests {
                     rows[$d - 1][0] = -1.0;
 
                     assert_eq!(
-                        SymmetricMatrix::try_new(Matrix::<$d>::from_rows(rows)),
+                        FiniteMatrix::from_rows(rows).and_then(SymmetricMatrix::try_new),
                         Err(LaError::Asymmetric {
                             row: 0,
                             col: $d - 1,
@@ -1671,17 +1875,17 @@ mod tests {
         };
     }
 
-    gen_symmetric_matrix_tests!(2);
-    gen_symmetric_matrix_tests!(3);
-    gen_symmetric_matrix_tests!(4);
-    gen_symmetric_matrix_tests!(5);
+    gen_ldlt_symmetry_proof_tests!(2);
+    gen_ldlt_symmetry_proof_tests!(3);
+    gen_ldlt_symmetry_proof_tests!(4);
+    gen_ldlt_symmetry_proof_tests!(5);
 
     #[test]
-    fn symmetric_matrix_try_new_rejects_nonfinite_before_asymmetry() {
+    fn matrix_ldlt_rejects_nonfinite_before_asymmetry() {
         let a = Matrix::<2>::from_rows([[1.0, f64::NAN], [0.0, 1.0]]);
 
         assert_eq!(
-            SymmetricMatrix::try_new(a),
+            a.ldlt(DEFAULT_PIVOT_TOL),
             Err(LaError::NonFinite {
                 row: Some(0),
                 col: 1,
@@ -1690,12 +1894,13 @@ mod tests {
     }
 
     #[test]
-    fn symmetric_matrix_into_matrix_roundtrips_storage() {
+    fn symmetric_matrix_into_matrix_roundtrips_storage_internally() {
         let a = Matrix::<2>::from_rows([[2.0, 1.0], [1.0, 3.0]]);
-        let symmetric = SymmetricMatrix::try_new(a).unwrap();
+        let symmetric = FiniteMatrix::try_new(a)
+            .and_then(SymmetricMatrix::try_new)
+            .unwrap();
 
-        assert_eq!(symmetric.as_matrix(), &a);
-        assert_eq!(Matrix::from(symmetric), a);
+        assert_eq!(symmetric.into_matrix(), a);
     }
 
     #[test]

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -1142,6 +1142,8 @@ mod tests {
                     let finite = FiniteMatrix::<$d>::from_rows(rows).unwrap();
 
                     assert_matrix_abs_eq(&finite.into_matrix(), &Matrix::<$d>::from_rows(rows));
+                    assert_matrix_abs_eq(&FiniteMatrix::<$d>::zero().into_matrix(), &Matrix::<$d>::zero());
+                    assert_matrix_abs_eq(&FiniteMatrix::<$d>::default().into_matrix(), &Matrix::<$d>::zero());
                     assert_eq!(finite.into_matrix().get(0, 0), Some(1.0));
                     assert_eq!(finite.into_matrix().get($d, 0), None);
                     assert_eq!(

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -9,6 +9,113 @@ pub struct Vector<const D: usize> {
     pub(crate) data: [f64; D],
 }
 
+/// Fixed-size vector whose stored entries are all finite.
+///
+/// This proof-carrying wrapper lets callers validate raw [`Vector`] values once
+/// at an input boundary, then pass the finite invariant into numerical
+/// algorithms without rediscovering that no stored entry is NaN or infinite.
+#[must_use]
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[allow(clippy::redundant_pub_crate)]
+pub(crate) struct FiniteVector<const D: usize> {
+    vector: Vector<D>,
+}
+
+impl<const D: usize> FiniteVector<D> {
+    /// Construct a finite vector without checking the invariant.
+    ///
+    /// This is crate-internal so public callers must use [`try_new`](Self::try_new)
+    /// or [`from_array`](Self::from_array), which preserve diagnostics for
+    /// rejected raw entries.
+    #[inline]
+    pub(crate) const fn new_unchecked(vector: Vector<D>) -> Self {
+        Self { vector }
+    }
+
+    /// Validate that every stored vector entry is finite.
+    /// # Errors
+    /// Returns [`LaError::NonFinite`] with `row: None` and the first offending
+    /// entry index when `vector` contains NaN or infinity.
+    #[inline]
+    pub const fn try_new(vector: Vector<D>) -> Result<Self, LaError> {
+        let mut i = 0;
+        while i < D {
+            if !vector.data[i].is_finite() {
+                return Err(LaError::non_finite_at(i));
+            }
+            i += 1;
+        }
+        Ok(Self::new_unchecked(vector))
+    }
+
+    /// Validate raw vector storage and construct a finite vector.
+    /// # Errors
+    /// Returns [`LaError::NonFinite`] with `row: None` and the first offending
+    /// entry index when `data` contains NaN or infinity.
+    #[inline]
+    pub const fn from_array(data: [f64; D]) -> Result<Self, LaError> {
+        Self::try_new(Vector::new(data))
+    }
+
+    /// All-zeros finite vector.
+    #[inline]
+    pub const fn zero() -> Self {
+        Self::new_unchecked(Vector::zero())
+    }
+
+    /// Consume the wrapper and return the underlying raw vector.
+    #[inline]
+    pub const fn into_vector(self) -> Vector<D> {
+        self.vector
+    }
+
+    /// Borrow the backing array without revalidating stored entries.
+    #[cfg(feature = "exact")]
+    #[inline]
+    pub(crate) const fn as_array(&self) -> &[f64; D] {
+        self.vector.as_array()
+    }
+
+    /// Consume and return the backing array.
+    #[inline]
+    #[must_use]
+    pub const fn into_array(self) -> [f64; D] {
+        self.vector.into_array()
+    }
+}
+
+impl<const D: usize> Default for FiniteVector<D> {
+    #[inline]
+    fn default() -> Self {
+        Self::zero()
+    }
+}
+
+impl<const D: usize> From<FiniteVector<D>> for Vector<D> {
+    #[inline]
+    fn from(value: FiniteVector<D>) -> Self {
+        value.into_vector()
+    }
+}
+
+impl<const D: usize> TryFrom<Vector<D>> for FiniteVector<D> {
+    type Error = LaError;
+
+    #[inline]
+    fn try_from(value: Vector<D>) -> Result<Self, Self::Error> {
+        Self::try_new(value)
+    }
+}
+
+impl<const D: usize> TryFrom<[f64; D]> for FiniteVector<D> {
+    type Error = LaError;
+
+    #[inline]
+    fn try_from(value: [f64; D]) -> Result<Self, Self::Error> {
+        Self::from_array(value)
+    }
+}
+
 impl<const D: usize> Vector<D> {
     /// Create a vector from a backing array.
     ///
@@ -137,7 +244,19 @@ impl<const D: usize> Vector<D> {
     /// or when the accumulated norm overflows to NaN or infinity.
     #[inline]
     pub const fn norm2_sq(self) -> Result<f64, LaError> {
-        self.dot(self)
+        let mut acc = 0.0;
+        let mut i = 0;
+        while i < D {
+            if !self.data[i].is_finite() {
+                return Err(LaError::non_finite_at(i));
+            }
+            acc = self.data[i].mul_add(self.data[i], acc);
+            if !acc.is_finite() {
+                return Err(LaError::non_finite_at(i));
+            }
+            i += 1;
+        }
+        Ok(acc)
     }
 }
 
@@ -156,6 +275,12 @@ mod tests {
 
     use approx::assert_abs_diff_eq;
     use pastey::paste;
+
+    fn assert_array_abs_eq<const D: usize>(actual: &[f64; D], expected: &[f64; D]) {
+        for i in 0..D {
+            assert_abs_diff_eq!(actual[i], expected[i], epsilon = 0.0);
+        }
+    }
 
     macro_rules! gen_public_api_vector_tests {
         ($d:literal) => {
@@ -307,6 +432,44 @@ mod tests {
 
                     assert_eq!(a.dot(b), Err(LaError::NonFinite { row: None, col: 0 }));
                     assert_eq!(a.norm2_sq(), Err(LaError::NonFinite { row: None, col: 0 }));
+                }
+
+                #[test]
+                fn [<finite_vector_accepts_and_roundtrips_ $d d>]() {
+                    let arr = {
+                        let mut arr = [0.0f64; $d];
+                        let values = [1.0f64, 2.0, 3.0, 4.0, 5.0];
+                        for (dst, src) in arr.iter_mut().zip(values.iter()) {
+                            *dst = *src;
+                        }
+                        arr
+                    };
+
+                    let finite = FiniteVector::<$d>::from_array(arr).unwrap();
+
+                    assert_array_abs_eq(&finite.into_array(), &arr);
+                    assert_array_abs_eq(&finite.into_vector().into_array(), &arr);
+                    assert_array_abs_eq(&FiniteVector::<$d>::zero().into_array(), &[0.0; $d]);
+                    assert_array_abs_eq(Vector::from(finite).as_array(), &arr);
+                    assert_array_abs_eq(
+                        &FiniteVector::<$d>::try_from(Vector::<$d>::new(arr)).unwrap().into_array(),
+                        &arr
+                    );
+                    assert_array_abs_eq(&FiniteVector::<$d>::try_from(arr).unwrap().into_array(), &arr);
+                }
+
+                #[test]
+                fn [<finite_vector_rejects_nonfinite_with_index_ $d d>]() {
+                    let mut arr = [1.0f64; $d];
+                    arr[$d - 1] = f64::INFINITY;
+
+                    assert_eq!(
+                        FiniteVector::<$d>::from_array(arr),
+                        Err(LaError::NonFinite {
+                            row: None,
+                            col: $d - 1,
+                        })
+                    );
                 }
             }
         };

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -450,6 +450,7 @@ mod tests {
                     assert_array_abs_eq(&finite.into_array(), &arr);
                     assert_array_abs_eq(&finite.into_vector().into_array(), &arr);
                     assert_array_abs_eq(&FiniteVector::<$d>::zero().into_array(), &[0.0; $d]);
+                    assert_array_abs_eq(&FiniteVector::<$d>::default().into_array(), &[0.0; $d]);
                     assert_array_abs_eq(Vector::from(finite).as_array(), &arr);
                     assert_array_abs_eq(
                         &FiniteVector::<$d>::try_from(Vector::<$d>::new(arr)).unwrap().into_array(),


### PR DESCRIPTION
- Parse matrices and vectors into crate-private finite proof types before factorization, exact arithmetic, and finite-sensitive matrix operations.
- Remove SymmetricMatrix from the public root and prelude surface; Matrix::ldlt now owns symmetry validation and reports typed Asymmetric errors.
- Split LDLT negative pivots into LaError::NotPositiveSemidefinite while keeping Singular for zero or too-small non-negative diagonals.
- Document determinant error coefficients as rounding-bound multipliers rather than tunable tolerances.

BREAKING CHANGE: SymmetricMatrix is no longer exported as public API; callers should use Matrix::ldlt and Matrix::first_asymmetry instead.
BREAKING CHANGE: LDLT factorization reports negative pivots as LaError::NotPositiveSemidefinite instead of LaError::Singular.

Closes #126

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New NotPositiveSemidefinite error reported when LDLT encounters negative diagonal values.

* **Bug Fixes**
  * LDLT/solvers now explicitly reject negative diagonals and non-finite inputs at API boundaries.
  * Finite-only code paths prevent NaN/∞ from being stored in successful results.

* **Documentation**
  * README expanded (input-validation, determinant error-bound details, API notes).
  * Roadmap reorganized to clarify API-invariant work and remaining blockers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->