### PR TITLE
feat(validation): guard public Rust examples against unwrap

### DIFF
--- a/benches/exact.rs
+++ b/benches/exact.rs
@@ -19,7 +19,16 @@
 use criterion::{BenchmarkGroup, Criterion, measurement::WallTime};
 use la_stack::{Matrix, Vector};
 use pastey::paste;
+use std::fmt::Display;
 use std::hint::black_box;
+
+/// Return a successful benchmark operation result or panic with the named operation.
+fn require_ok<T, E: Display>(result: Result<T, E>, operation: &str) -> T {
+    match result {
+        Ok(value) => value,
+        Err(err) => panic!("{operation} failed: {err}"),
+    }
+}
 
 #[inline]
 #[allow(clippy::cast_precision_loss)]
@@ -134,34 +143,34 @@ fn bench_extreme_group<const D: usize>(
 ) {
     group.bench_function("det_sign_exact", |bencher| {
         bencher.iter(|| {
-            let sign = black_box(m)
-                .det_sign_exact()
-                .expect("finite matrix entries");
+            let sign = require_ok(black_box(m).det_sign_exact(), "exact determinant sign");
             black_box(sign);
         });
     });
 
     group.bench_function("det_exact", |bencher| {
         bencher.iter(|| {
-            let det = black_box(m).det_exact().expect("finite matrix entries");
+            let det = require_ok(black_box(m).det_exact(), "exact determinant");
             black_box(det);
         });
     });
 
     group.bench_function("solve_exact", |bencher| {
         bencher.iter(|| {
-            let x = black_box(m)
-                .solve_exact(black_box(rhs))
-                .expect("non-singular matrix with finite entries");
+            let x = require_ok(
+                black_box(m).solve_exact(black_box(rhs)),
+                "exact linear solve",
+            );
             let _ = black_box(x);
         });
     });
 
     group.bench_function("solve_exact_f64", |bencher| {
         bencher.iter(|| {
-            let x = black_box(m)
-                .solve_exact_f64(black_box(rhs))
-                .expect("solution representable in f64");
+            let x = require_ok(
+                black_box(m).solve_exact_f64(black_box(rhs)),
+                "exact linear solve converted to f64",
+            );
             let _ = black_box(x);
         });
     });
@@ -178,9 +187,7 @@ macro_rules! gen_exact_benches_for_dim {
             // === f64 baselines ===
             [<group_d $d>].bench_function("det", |bencher| {
                 bencher.iter(|| {
-                    let det = black_box(a)
-                        .det()
-                        .expect("diagonally dominant matrix is non-singular");
+                    let det = require_ok(black_box(a).det(), "f64 determinant");
                     black_box(det);
                 });
             });
@@ -195,7 +202,7 @@ macro_rules! gen_exact_benches_for_dim {
             // === det_exact (BigRational result) ===
             [<group_d $d>].bench_function("det_exact", |bencher| {
                 bencher.iter(|| {
-                    let det = black_box(a).det_exact().expect("finite matrix entries");
+                    let det = require_ok(black_box(a).det_exact(), "exact determinant");
                     black_box(det);
                 });
             });
@@ -203,9 +210,10 @@ macro_rules! gen_exact_benches_for_dim {
             // === det_exact_f64 (exact → f64) ===
             [<group_d $d>].bench_function("det_exact_f64", |bencher| {
                 bencher.iter(|| {
-                    let det = black_box(a)
-                        .det_exact_f64()
-                        .expect("det representable in f64");
+                    let det = require_ok(
+                        black_box(a).det_exact_f64(),
+                        "exact determinant converted to f64",
+                    );
                     black_box(det);
                 });
             });
@@ -213,9 +221,7 @@ macro_rules! gen_exact_benches_for_dim {
             // === det_sign_exact (adaptive: fast filter + exact fallback) ===
             [<group_d $d>].bench_function("det_sign_exact", |bencher| {
                 bencher.iter(|| {
-                    let sign = black_box(a)
-                        .det_sign_exact()
-                        .expect("finite matrix entries");
+                    let sign = require_ok(black_box(a).det_sign_exact(), "exact determinant sign");
                     black_box(sign);
                 });
             });
@@ -223,9 +229,10 @@ macro_rules! gen_exact_benches_for_dim {
             // === solve_exact (BigRational result) ===
             [<group_d $d>].bench_function("solve_exact", |bencher| {
                 bencher.iter(|| {
-                    let x = black_box(a)
-                        .solve_exact(black_box(rhs))
-                        .expect("diagonally dominant matrix is non-singular");
+                    let x = require_ok(
+                        black_box(a).solve_exact(black_box(rhs)),
+                        "exact linear solve",
+                    );
                     black_box(x);
                 });
             });
@@ -233,9 +240,10 @@ macro_rules! gen_exact_benches_for_dim {
             // === solve_exact_f64 (exact → f64) ===
             [<group_d $d>].bench_function("solve_exact_f64", |bencher| {
                 bencher.iter(|| {
-                    let x = black_box(a)
-                        .solve_exact_f64(black_box(rhs))
-                        .expect("solution representable in f64");
+                    let x = require_ok(
+                        black_box(a).solve_exact_f64(black_box(rhs)),
+                        "exact linear solve converted to f64",
+                    );
                     black_box(x);
                 });
             });

--- a/benches/vs_linalg.rs
+++ b/benches/vs_linalg.rs
@@ -12,7 +12,21 @@ use faer::linalg::solvers::{PartialPivLu, Solve};
 use faer::perm::PermRef;
 use la_stack::{DEFAULT_PIVOT_TOL, Matrix, Vector};
 use pastey::paste;
+use std::fmt::Display;
 use std::hint::black_box;
+
+/// Return a successful benchmark operation result or panic with the named operation.
+fn require_ok<T, E: Display>(result: Result<T, E>, operation: &str) -> T {
+    match result {
+        Ok(value) => value,
+        Err(err) => panic!("{operation} failed: {err}"),
+    }
+}
+
+/// Return a present third-party benchmark result or panic with the named operation.
+fn require_some<T>(value: Option<T>, operation: &str) -> T {
+    value.unwrap_or_else(|| panic!("{operation} returned no result"))
+}
 
 fn faer_perm_sign(p: PermRef<'_, usize>) -> f64 {
     // Sign(det(P)) for a permutation matrix P is +1 for even permutations, -1 for odd.
@@ -145,9 +159,7 @@ macro_rules! gen_vs_linalg_benches_for_dim {
                 let fv2 = faer::Mat::<f64>::from_fn($d, 1, |i, _| vector_entry(i, 1.0));
 
                 // Precompute LU once for solve-only / det-only benchmarks.
-                let a_lu = a
-                    .lu(DEFAULT_PIVOT_TOL)
-                    .expect("matrix should be non-singular");
+                let a_lu = require_ok(a.lu(DEFAULT_PIVOT_TOL), "precomputed la_stack LU");
                 let na_lu = na.clone().lu();
                 let fa_lu = fa.partial_piv_lu();
 
@@ -156,13 +168,11 @@ macro_rules! gen_vs_linalg_benches_for_dim {
                 // === Determinant via LU (factor + det) ===
                 [<group_d $d>].bench_function("la_stack_det_via_lu", |bencher| {
                     bencher.iter(|| {
-                        let lu = black_box(a)
-                            .lu(DEFAULT_PIVOT_TOL)
-                            .expect("matrix should be non-singular");
-                        let det = match lu.det() {
-                            Ok(det) => det,
-                            Err(err) => panic!("finite benchmark matrix determinant failed: {err}"),
-                        };
+                        let lu = require_ok(
+                            black_box(a).lu(DEFAULT_PIVOT_TOL),
+                            "la_stack LU factorization",
+                        );
+                        let det = require_ok(lu.det(), "la_stack LU determinant");
                         black_box(det);
                     });
                 });
@@ -186,7 +196,7 @@ macro_rules! gen_vs_linalg_benches_for_dim {
                 // === Determinant via det() (closed-form for D≤4, LU for D≥5) ===
                 [<group_d $d>].bench_function("la_stack_det", |bencher| {
                     bencher.iter(|| {
-                        let det = black_box(a).det().expect("matrix should be non-singular");
+                        let det = require_ok(black_box(a).det(), "la_stack determinant");
                         black_box(det);
                     });
                 });
@@ -194,9 +204,10 @@ macro_rules! gen_vs_linalg_benches_for_dim {
                 // === LU factorization ===
                 [<group_d $d>].bench_function("la_stack_lu", |bencher| {
                     bencher.iter(|| {
-                        let lu = black_box(a)
-                            .lu(DEFAULT_PIVOT_TOL)
-                            .expect("matrix should be non-singular");
+                        let lu = require_ok(
+                            black_box(a).lu(DEFAULT_PIVOT_TOL),
+                            "la_stack LU factorization",
+                        );
                         let _ = black_box(lu);
                     });
                 });
@@ -218,12 +229,14 @@ macro_rules! gen_vs_linalg_benches_for_dim {
                 // === LU solve (factor + solve) ===
                 [<group_d $d>].bench_function("la_stack_lu_solve", |bencher| {
                     bencher.iter(|| {
-                        let lu = black_box(a)
-                            .lu(DEFAULT_PIVOT_TOL)
-                            .expect("matrix should be non-singular");
-                        let x = lu
-                            .solve_vec(black_box(rhs))
-                            .expect("solve should succeed");
+                        let lu = require_ok(
+                            black_box(a).lu(DEFAULT_PIVOT_TOL),
+                            "la_stack LU factorization",
+                        );
+                        let x = require_ok(
+                            lu.solve_vec(black_box(rhs)),
+                            "la_stack LU solve",
+                        );
                         let _ = black_box(x);
                     });
                 });
@@ -231,9 +244,7 @@ macro_rules! gen_vs_linalg_benches_for_dim {
                 [<group_d $d>].bench_function("nalgebra_lu_solve", |bencher| {
                     bencher.iter(|| {
                         let lu = black_box(na.clone()).lu();
-                        let x = lu
-                            .solve(black_box(&nrhs))
-                            .expect("solve should succeed");
+                        let x = require_some(lu.solve(black_box(&nrhs)), "nalgebra LU solve");
                         black_box(x);
                     });
                 });
@@ -249,18 +260,20 @@ macro_rules! gen_vs_linalg_benches_for_dim {
                 // === Solve using a precomputed LU ===
                 [<group_d $d>].bench_function("la_stack_solve_from_lu", |bencher| {
                     bencher.iter(|| {
-                        let x = a_lu
-                            .solve_vec(black_box(rhs))
-                            .expect("solve should succeed");
+                        let x = require_ok(
+                            a_lu.solve_vec(black_box(rhs)),
+                            "precomputed la_stack LU solve",
+                        );
                         let _ = black_box(x);
                     });
                 });
 
                 [<group_d $d>].bench_function("nalgebra_solve_from_lu", |bencher| {
                     bencher.iter(|| {
-                        let x = na_lu
-                            .solve(black_box(&nrhs))
-                            .expect("solve should succeed");
+                        let x = require_some(
+                            na_lu.solve(black_box(&nrhs)),
+                            "precomputed nalgebra LU solve",
+                        );
                         black_box(x);
                     });
                 });
@@ -275,10 +288,7 @@ macro_rules! gen_vs_linalg_benches_for_dim {
                 // === Determinant from a precomputed LU ===
                 [<group_d $d>].bench_function("la_stack_det_from_lu", |bencher| {
                     bencher.iter(|| {
-                        let det = match a_lu.det() {
-                            Ok(det) => det,
-                            Err(err) => panic!("finite benchmark matrix determinant failed: {err}"),
-                        };
+                        let det = require_ok(a_lu.det(), "precomputed la_stack LU determinant");
                         black_box(det);
                     });
                 });
@@ -300,7 +310,7 @@ macro_rules! gen_vs_linalg_benches_for_dim {
                 // === Vector dot product ===
                 [<group_d $d>].bench_function("la_stack_dot", |bencher| {
                     bencher.iter(|| {
-                        let result = black_box(v1).dot(black_box(v2)).unwrap();
+                        let result = require_ok(black_box(v1).dot(black_box(v2)), "la_stack dot");
                         black_box(result);
                     });
                 });
@@ -327,7 +337,7 @@ macro_rules! gen_vs_linalg_benches_for_dim {
                 // === Vector norm squared ===
                 [<group_d $d>].bench_function("la_stack_norm2_sq", |bencher| {
                     bencher.iter(|| {
-                        let result = black_box(v1).norm2_sq().unwrap();
+                        let result = require_ok(black_box(v1).norm2_sq(), "la_stack norm2_sq");
                         black_box(result);
                     });
                 });
@@ -354,7 +364,7 @@ macro_rules! gen_vs_linalg_benches_for_dim {
                 // === Matrix infinity norm (max absolute row sum) ===
                 [<group_d $d>].bench_function("la_stack_inf_norm", |bencher| {
                     bencher.iter(|| {
-                        let result = black_box(a).inf_norm().unwrap();
+                        let result = require_ok(black_box(a).inf_norm(), "la_stack inf_norm");
                         black_box(result);
                     });
                 });

--- a/examples/const_det_4x4.rs
+++ b/examples/const_det_4x4.rs
@@ -20,7 +20,7 @@ const DET: f64 = match MAT.det_direct() {
     Err(_) => panic!("matrix entries must be finite"),
 };
 
-fn main() {
+fn main() -> Result<(), LaError> {
     println!("4×4 matrix:");
     for r in 0..4 {
         print!("  [");
@@ -28,10 +28,12 @@ fn main() {
             if c > 0 {
                 print!(", ");
             }
-            print!("{:5.1}", MAT.get(r, c).unwrap());
+            print!("{:5.1}", MAT.get_checked(r, c)?);
         }
         println!("]");
     }
     println!();
     println!("det (computed at compile time) = {DET}");
+
+    Ok(())
 }

--- a/examples/exact_sign_3x3.rs
+++ b/examples/exact_sign_3x3.rs
@@ -8,7 +8,7 @@
 
 use la_stack::prelude::*;
 
-fn main() {
+fn main() -> Result<(), LaError> {
     // Base matrix: rows in arithmetic progression → exactly singular (det = 0).
     //   [[1, 2, 3],
     //    [4, 5, 6],
@@ -23,8 +23,8 @@ fn main() {
         [7.0, 8.0, 9.0],
     ]);
 
-    let sign = m.det_sign_exact().unwrap();
-    let det_f64 = m.det().unwrap();
+    let sign = m.det_sign_exact()?;
+    let det_f64 = m.det()?;
 
     println!("Near-singular 3×3 matrix (perturbation = 2^-50 ≈ {perturbation:.2e}):");
     for r in 0..3 {
@@ -33,7 +33,7 @@ fn main() {
             if c > 0 {
                 print!(", ");
             }
-            print!("{:22.18}", m.get(r, c).unwrap());
+            print!("{:22.18}", m.get_checked(r, c)?);
         }
         println!("]");
     }
@@ -42,4 +42,6 @@ fn main() {
     println!("det_sign_exact()   = {sign}");
     println!();
     println!("The exact sign is −1 (negative), matching the analytical result.");
+
+    Ok(())
 }

--- a/examples/ldlt_solve_3x3.rs
+++ b/examples/ldlt_solve_3x3.rs
@@ -26,7 +26,7 @@ fn main() -> Result<(), LaError> {
             if c > 0 {
                 print!(", ");
             }
-            print!("{:5.1}", a.get(r, c).unwrap());
+            print!("{:5.1}", a.get_checked(r, c)?);
         }
         println!("]");
     }

--- a/justfile
+++ b/justfile
@@ -389,7 +389,7 @@ help-workflows:
 # Lint groups (delaunay-style)
 lint: lint-code lint-docs lint-config
 
-lint-code: fmt-check clippy doc-check python-check shell-check semgrep
+lint-code: fmt-check clippy doc-check python-check shell-check semgrep semgrep-test
 
 lint-config: validate-json toml-lint toml-fmt-check yaml-check action-lint zizmor
 
@@ -461,11 +461,26 @@ python-sync: _ensure-uv
 
 python-typecheck: python-sync
     uv run ty check scripts/
-    uv run mypy scripts/archive_changelog.py scripts/bench_compare.py scripts/criterion_dim_plot.py scripts/tag_release.py scripts/postprocess_changelog.py scripts/subprocess_utils.py
+    uv run mypy scripts/archive_changelog.py scripts/bench_compare.py scripts/check_semgrep_fixtures.py scripts/criterion_dim_plot.py scripts/tag_release.py scripts/postprocess_changelog.py scripts/subprocess_utils.py
 
 # Repository-owned Semgrep rules for project-specific diagnostics.
 semgrep: _ensure-uv
     uv run semgrep --metrics off --error --strict --timeout 30 --config semgrep.yaml .
+
+# Fixture tests for repository-owned Semgrep rules.
+semgrep-test: _ensure-uv
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    check_semgrep_fixture() {
+        target="$1"
+        json="$(uv run semgrep scan --metrics off --json --quiet --strict --config semgrep.yaml "$target")"
+        SEMGREP_JSON="$json" uv run scripts/check_semgrep_fixtures.py "$target"
+    }
+
+    while IFS= read -r -d '' fixture; do
+        check_semgrep_fixture "$fixture"
+    done < <(find tests/semgrep -type f ! -name '*.fixed' -print0)
 
 # Setup
 setup: setup-tools

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ tag-release = "tag_release:main"
 # Configure setuptools to find modules in scripts/ directory.
 [tool.setuptools]
 package-dir = { "" = "scripts" }
-py-modules = [ "archive_changelog", "bench_compare", "criterion_dim_plot", "postprocess_changelog", "subprocess_utils", "tag_release" ]
+py-modules = [ "archive_changelog", "bench_compare", "check_semgrep_fixtures", "criterion_dim_plot", "postprocess_changelog", "subprocess_utils", "tag_release" ]
 
 [tool.ruff]
 line-length = 160
@@ -89,6 +89,7 @@ ignore = [
 known-first-party = [
     "archive_changelog",
     "bench_compare",
+    "check_semgrep_fixtures",
     "criterion_dim_plot",
     "postprocess_changelog",
     "subprocess_utils",

--- a/scripts/check_semgrep_fixtures.py
+++ b/scripts/check_semgrep_fixtures.py
@@ -10,7 +10,7 @@ import sys
 from pathlib import Path
 from typing import Any
 
-RULE_ANNOTATION = re.compile(r"\b(?:ruleid|todoruleid):\s*([A-Za-z0-9_.-]+(?:\s*,\s*[A-Za-z0-9_.-]+)*)")
+RULE_ANNOTATION = re.compile(r"\bruleid:\s*([A-Za-z0-9_.-]+(?:\s*,\s*[A-Za-z0-9_.-]+)*)")
 
 
 def _path_argument(argv: list[str]) -> Path | None:
@@ -37,10 +37,18 @@ def _semgrep_results() -> dict[str, Any] | None:
         print("Missing required SEMGREP_JSON environment variable", file=sys.stderr)
         return None
     try:
-        return json.loads(semgrep_json)
+        data = json.loads(semgrep_json)
     except json.JSONDecodeError as error:
         print(f"Invalid JSON in SEMGREP_JSON: {error}", file=sys.stderr)
         return None
+
+    if not isinstance(data, dict):
+        print("Invalid SEMGREP_JSON shape: expected a JSON object", file=sys.stderr)
+        return None
+    if not isinstance(data.get("results"), list):
+        print("Invalid SEMGREP_JSON shape: expected 'results' to be a list", file=sys.stderr)
+        return None
+    return data
 
 
 def main() -> int:
@@ -57,7 +65,27 @@ def main() -> int:
     if data is None:
         return 1
 
-    actual: collections.Counter[str] = collections.Counter(result["check_id"] for result in data["results"])
+    results = data["results"]
+    actual: collections.Counter[str] = collections.Counter()
+    malformed_results: list[str] = []
+    for index, result in enumerate(results):
+        if not isinstance(result, dict):
+            malformed_results.append(f"result {index} is not an object")
+            continue
+
+        check_id = result.get("check_id")
+        if not isinstance(check_id, str):
+            malformed_results.append(f"result {index} is missing string field 'check_id'")
+            continue
+
+        actual.update([check_id])
+
+    if malformed_results:
+        print("Invalid SEMGREP_JSON shape:", file=sys.stderr)
+        for malformed in malformed_results:
+            print(f"  {malformed}", file=sys.stderr)
+        return 1
+
     if actual == expected:
         return 0
 

--- a/scripts/check_semgrep_fixtures.py
+++ b/scripts/check_semgrep_fixtures.py
@@ -1,0 +1,72 @@
+"""Validate repository-owned Semgrep fixture annotations."""
+
+from __future__ import annotations
+
+import collections
+import json
+import os
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+RULE_ANNOTATION = re.compile(r"\b(?:ruleid|todoruleid):\s*([A-Za-z0-9_.-]+(?:\s*,\s*[A-Za-z0-9_.-]+)*)")
+
+
+def _path_argument(argv: list[str]) -> Path | None:
+    if len(argv) <= 1:
+        print("Missing required path argument: sys.argv[1]", file=sys.stderr)
+        return None
+
+    path = Path(argv[1])
+    if not path.exists():
+        print(f"path argument does not exist: {path}", file=sys.stderr)
+        return None
+    if not path.is_file():
+        print(f"path argument is not a file: {path}", file=sys.stderr)
+        return None
+    if not os.access(path, os.R_OK):
+        print(f"path argument is not readable: {path}", file=sys.stderr)
+        return None
+    return path
+
+
+def _semgrep_results() -> dict[str, Any] | None:
+    semgrep_json = os.environ.get("SEMGREP_JSON")
+    if semgrep_json is None:
+        print("Missing required SEMGREP_JSON environment variable", file=sys.stderr)
+        return None
+    try:
+        return json.loads(semgrep_json)
+    except json.JSONDecodeError as error:
+        print(f"Invalid JSON in SEMGREP_JSON: {error}", file=sys.stderr)
+        return None
+
+
+def main() -> int:
+    path = _path_argument(sys.argv)
+    if path is None:
+        return 1
+
+    expected: collections.Counter[str] = collections.Counter()
+    for line in path.read_text(encoding="utf-8").splitlines():
+        for match in RULE_ANNOTATION.finditer(line):
+            expected.update(rule_id.strip() for rule_id in match.group(1).split(",") if rule_id.strip())
+
+    data = _semgrep_results()
+    if data is None:
+        return 1
+
+    actual: collections.Counter[str] = collections.Counter(result["check_id"] for result in data["results"])
+    if actual == expected:
+        return 0
+
+    print(f"Semgrep fixture mismatch in {path}")
+    for rule in sorted(expected.keys() | actual.keys()):
+        if expected[rule] != actual[rule]:
+            print(f"  {rule}: expected {expected[rule]}, got {actual[rule]}")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/semgrep.yaml
+++ b/semgrep.yaml
@@ -71,6 +71,44 @@ rules:
         - "/src/**/*.rs"
     pattern-regex: '(?m)(?<!#\[non_exhaustive\]\n)^\s*pub\s+enum\s+[A-Za-z_][A-Za-z0-9_]*Error(?:<[^>{}]*)?\s*\{'
 
+  - id: la-stack.rust.no-unwrap-expect-in-doctests
+    languages:
+      - generic
+    severity: WARNING
+    message: "Use fallible doctest flow instead of unwrap() or expect() in public documentation examples."
+    metadata:
+      category: correctness
+      rationale: >-
+        Public Rust documentation examples should model typed error handling
+        with Result and ? rather than teaching panic-based control flow.
+    paths:
+      include:
+        - "/src/**/*.rs"
+        - "/tests/semgrep/doctests/**/*.txt"
+      exclude:
+        - "/tests/semgrep/src/**"
+    pattern-regex: '^\s*//[!/]\s*(?:#\s*)?.*(?:\b[\w:]+|[\]\)])\.(unwrap|expect)\s*\('
+
+  - id: la-stack.rust.no-unwrap-expect-in-benches-examples
+    languages:
+      - rust
+    severity: WARNING
+    message: "Use explicit fixture error handling instead of unwrap() or expect() in benchmarks and examples."
+    metadata:
+      category: correctness
+      rationale: >-
+        Benchmarks and public examples should keep failure modes explicit so
+        users and CI see the operation that failed instead of a panic-only
+        unwrap/expect path.
+    paths:
+      include:
+        - "/benches/**/*.rs"
+        - "/examples/**/*.rs"
+        - "/tests/semgrep/src/project_rules/bench_example_usage.rs"
+    pattern-either:
+      - pattern: $VALUE.unwrap()
+      - pattern: $VALUE.expect(...)
+
   - id: la-stack.github-actions.external-action-sha-pinned
     languages:
       - regex

--- a/tests/semgrep/doctests/unwrap_expect.txt
+++ b/tests/semgrep/doctests/unwrap_expect.txt
@@ -1,0 +1,14 @@
+// ruleid: la-stack.rust.no-unwrap-expect-in-doctests
+/// let value = Some(1_u32).unwrap();
+
+// ruleid: la-stack.rust.no-unwrap-expect-in-doctests
+//! let value = Ok::<u32, la_stack::LaError>(1).expect("doctest should not panic");
+
+// ok: la-stack.rust.no-unwrap-expect-in-doctests
+/// # fn main() -> Result<(), la_stack::LaError> { Ok(()) }
+
+// ok: la-stack.rust.no-unwrap-expect-in-doctests
+/// Do not use `.unwrap()` in public examples.
+
+// ok: la-stack.rust.no-unwrap-expect-in-doctests
+/// Prefer `?` to `.expect("message")` in public examples.

--- a/tests/semgrep/src/project_rules/bench_example_usage.rs
+++ b/tests/semgrep/src/project_rules/bench_example_usage.rs
@@ -1,0 +1,13 @@
+#![forbid(unsafe_code)]
+#![allow(dead_code)]
+
+fn benchmark_and_example_fixture(result: Result<u32, &'static str>, value: Option<u32>) {
+    // ruleid: la-stack.rust.no-unwrap-expect-in-benches-examples
+    let _ = result.unwrap();
+
+    // ruleid: la-stack.rust.no-unwrap-expect-in-benches-examples
+    let _ = value.expect("benchmarks and examples should avoid expect");
+
+    // ok: la-stack.rust.no-unwrap-expect-in-benches-examples
+    let _ = result.unwrap_or(0);
+}


### PR DESCRIPTION
- Add repository-owned Semgrep rules for unwrap and expect usage in public doctests, examples, and benchmarks.
- Add fixture-based Semgrep rule tests and include them in the lint workflow.
- Update examples and benchmarks to model typed fallible flow or operation-labeled benchmark failures.

Closes #125

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Examples now use fallible error propagation instead of panicking for safer, clearer failures.
  * Benchmarks standardized error handling for more consistent failure messages during runs.

* **Tests**
  * Added static analysis rules to forbid panicking patterns in docs/examples and benchmarks.
  * Added fixture-based tests to validate those rules.

* **Chores**
  * Introduced a new validation script and expanded lint tasks to run fixture checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->