### PR TITLE
fix(invariants): revalidate public compute inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Clarify determinant documentation around uncertified `det()` bounds.
   - Keep SPD determinant proptests on the tolerance-aware LU path.
 
+- Simplify finite proof wrappers [`54b603c`](https://github.com/acgetchell/la-stack/commit/54b603c21f0eb5b4d63ff334fac7f8cc325ebc2e)
+
+  - Use the checked proof-wrapper constructors as the single internal path for finite matrices and vectors.
+  - Remove exact-arithmetic tests that duplicated the matrix and vector non-finite boundary checks.
+
 ### Dependencies
 
 - Bump taiki-e/install-action from 2.75.18 to 2.75.22 [`d6c944b`](https://github.com/acgetchell/la-stack/commit/d6c944bb7dd30bb00dfe820bc355c4351cb1f242)

--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ compose the same bound themselves.
 
 | Type | Storage | Purpose | Key methods |
 |---|---|---|---|
-| `Vector<D>` | `[f64; D]` | Fixed-length vector for input and computation | `new`, `zero`, `dot`, `norm2_sq` |
+| `Vector<D>` | `[f64; D]` | Fixed-length vector for input and computation | `try_new`, `zero`, `dot`, `norm2_sq` |
 | `Matrix<D>` | `[[f64; D]; D]` | Square matrix for input and computation | See below |
 | `Lu<D>` | `Matrix<D>` + pivot array | Factorization for solves/det | `solve_vec`, `det` |
 | `Ldlt<D>` | `Matrix<D>` | Factorization for symmetric SPD/PSD solves/det | `solve_vec`, `det` |
@@ -299,8 +299,8 @@ Storage shown above reflects the intentional `f64` scalar model.
 `Matrix<D>` key methods: `lu`, `ldlt`, `det`, `det_direct`, `det_errbound`,
 `det_exact`¹, `det_exact_f64`¹, `det_sign_exact`¹, `solve_exact`¹, `solve_exact_f64`¹.
 Matrix and vector methods validate non-finite inputs at public API boundaries and
-carry internal proof types through computation so successful factors do not store
-NaN or infinity.
+carry private proof-bearing types through computation so successful factors do
+not store NaN or infinity.
 
 ¹ Requires `features = ["exact"]`.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -58,12 +58,18 @@ Completed foundation work:
 Current API-invariant cleanup:
 
 - [#126](https://github.com/acgetchell/la-stack/issues/126) is resolved as an
-  internal parse-don't-validate design rather than a public proof-type API.
+  internal parse-don't-validate design rather than a public proof-bearing API.
   `Matrix<D>` and `Vector<D>` remain the raw boundary types so callers can pass
   deserialized, fixture, or otherwise unchecked `f64` storage and receive
   structured diagnostics. Crate-private `FiniteMatrix<D>` and
-  `FiniteVector<D>` carry the finite-entry proof behind the scenes for LU,
-  LDLT, determinant, error-bound, and exact-arithmetic paths.
+  `FiniteVector<D>` are validated domain types that carry the finite-entry proof
+  behind the scenes for LU, LDLT, determinant, error-bound, and exact-arithmetic
+  paths.
+- The public prelude stays focused on downstream composition: raw boundary
+  types, factorization handles, tolerances, crate errors, dispatch helpers, and
+  documented constants. Proof-bearing wrappers remain crate-private, and
+  exact-arithmetic integer/rational re-exports remain gated behind the `"exact"`
+  feature.
 - The public LDLT API remains `Matrix::ldlt`. Symmetry proof storage is kept
   internal, `SymmetricMatrix` is not exported, asymmetric inputs return
   `LaError::Asymmetric`, and negative LDLT pivots return

--- a/src/exact.rs
+++ b/src/exact.rs
@@ -59,11 +59,11 @@
 //!
 //! ## Validation
 //!
-//! Public exact methods parse raw `Matrix` / `Vector` values into internal finite
-//! proof types before reaching the integer-Bareiss core.  The decomposition
-//! helpers for those proof types can then call `f64_decompose` without repeating
-//! stored-entry validation; `f64_decompose` itself is therefore never called with
-//! non-finite input from the public API.
+//! Public exact methods parse raw `Matrix` / `Vector` values into internal
+//! finite proof-bearing types before reaching the integer-Bareiss core. The
+//! decomposition helpers for those validated domain types can then call
+//! `f64_decompose` without repeating stored-entry validation; `f64_decompose`
+//! itself is therefore never called with non-finite input from the public API.
 
 use core::hint::cold_path;
 use core::mem::take;
@@ -433,7 +433,7 @@ fn gauss_solve_finite<const D: usize>(
 /// Solve an exact integer-scaled augmented system from decomposed components.
 ///
 /// Forward elimination runs in [`BigInt`] using fraction-free Bareiss updates
-/// [7]. This is exact arithmetic, so there is no floating-point conditioning or
+/// \[7\]. This is exact arithmetic, so there is no floating-point conditioning or
 /// roundoff error in the elimination itself; ill-conditioned inputs can still
 /// produce large exact numerators and denominators in the final solution. The
 /// elimination phase performs `O(D³)` integer operations and Bareiss exact
@@ -536,7 +536,7 @@ impl<const D: usize> FiniteMatrix<D> {
             }
             result[i] = f;
         }
-        Ok(FiniteVector::new(Vector::new_unchecked(result)))
+        Ok(FiniteVector::new_unchecked(Vector::new_unchecked(result)))
     }
 
     /// Exact determinant sign for an already finite matrix.
@@ -605,6 +605,8 @@ impl<const D: usize> Matrix<D> {
     /// ```
     ///
     /// # Errors
+    /// Returns [`LaError::NonFinite`] if stored matrix entries are NaN or infinity.
+    ///
     /// Returns [`LaError::Overflow`] if determinant scaling overflows the internal
     /// exponent representation.
     ///
@@ -612,7 +614,7 @@ impl<const D: usize> Matrix<D> {
     /// the internal determinant exponent calculation.
     #[inline]
     pub fn det_exact(&self) -> Result<BigRational, LaError> {
-        FiniteMatrix::new(*self).det_exact()
+        FiniteMatrix::new(*self)?.det_exact()
     }
 
     /// Exact determinant converted to `f64`.
@@ -637,12 +639,14 @@ impl<const D: usize> Matrix<D> {
     /// ```
     ///
     /// # Errors
+    /// Returns [`LaError::NonFinite`] if stored matrix entries are NaN or infinity.
+    ///
     /// Returns [`LaError::Overflow`] if determinant scaling overflows the internal
     /// exponent representation or if the exact determinant is too large to
     /// represent as a finite `f64`.
     #[inline]
     pub fn det_exact_f64(&self) -> Result<f64, LaError> {
-        FiniteMatrix::new(*self).det_exact_f64()
+        FiniteMatrix::new(*self)?.det_exact_f64()
     }
 
     /// Exact linear system solve using hybrid integer/rational arithmetic.
@@ -688,11 +692,14 @@ impl<const D: usize> Matrix<D> {
     /// ```
     ///
     /// # Errors
+    /// Returns [`LaError::NonFinite`] if stored matrix or right-hand-side entries
+    /// are NaN or infinity.
+    ///
     /// Returns [`LaError::Singular`] if the matrix is exactly singular.
     #[inline]
     pub fn solve_exact(&self, b: Vector<D>) -> Result<[BigRational; D], LaError> {
-        let finite_m = FiniteMatrix::new(*self);
-        let finite_b = FiniteVector::new(b);
+        let finite_m = FiniteMatrix::new(*self)?;
+        let finite_b = FiniteVector::new(b)?;
         finite_m.solve_exact(finite_b)
     }
 
@@ -720,13 +727,16 @@ impl<const D: usize> Matrix<D> {
     /// ```
     ///
     /// # Errors
+    /// Returns [`LaError::NonFinite`] if stored matrix or right-hand-side entries
+    /// are NaN or infinity.
+    ///
     /// Returns [`LaError::Singular`] if the matrix is exactly singular.
     /// Returns [`LaError::Overflow`] if any component of the exact solution is
     /// too large to represent as a finite `f64`.
     #[inline]
     pub fn solve_exact_f64(&self, b: Vector<D>) -> Result<Vector<D>, LaError> {
-        let finite_m = FiniteMatrix::new(*self);
-        let finite_b = FiniteVector::new(b);
+        let finite_m = FiniteMatrix::new(*self)?;
+        let finite_b = FiniteVector::new(b)?;
         Ok(finite_m.solve_exact_f64(finite_b)?.into_vector())
     }
 
@@ -767,11 +777,11 @@ impl<const D: usize> Matrix<D> {
     /// ```
     ///
     /// # Errors
-    /// This exact sign path has no additional runtime errors for finite
-    /// matrices.
+    /// Returns [`LaError::NonFinite`] if stored matrix entries are NaN or infinity.
+    /// This exact sign path has no additional runtime errors for finite matrices.
     #[inline]
     pub fn det_sign_exact(&self) -> Result<i8, LaError> {
-        FiniteMatrix::new(*self).det_sign_exact()
+        FiniteMatrix::new(*self)?.det_sign_exact()
     }
 }
 
@@ -833,8 +843,8 @@ mod tests {
             paste! {
                 #[test]
                 fn [<internal_finite_exact_paths_reuse_validation_ $d d>]() {
-                    let a = FiniteMatrix::<$d>::new(Matrix::<$d>::identity());
-                    let b = FiniteVector::<$d>::new(Vector::<$d>::new([1.0; $d]));
+                    let a = FiniteMatrix::<$d>::new(Matrix::<$d>::identity()).unwrap();
+                    let b = FiniteVector::<$d>::new(Vector::<$d>::new([1.0; $d])).unwrap();
 
                     assert_eq!(
                         a.det_exact().unwrap(),
@@ -861,6 +871,53 @@ mod tests {
     gen_internal_finite_exact_tests!(3);
     gen_internal_finite_exact_tests!(4);
     gen_internal_finite_exact_tests!(5);
+
+    macro_rules! gen_public_exact_revalidation_tests {
+        ($d:literal) => {
+            paste! {
+                #[test]
+                fn [<public_exact_methods_revalidate_unchecked_matrix_storage_ $d d>]() {
+                    let mut rows = [[0.0f64; $d]; $d];
+                    for i in 0..$d {
+                        rows[i][i] = 1.0;
+                    }
+                    rows[0][$d - 1] = f64::NAN;
+                    let raw = Matrix::<$d>::from_rows_unchecked(rows);
+                    let rhs = Vector::<$d>::new([1.0; $d]);
+                    let expected = LaError::NonFinite {
+                        row: Some(0),
+                        col: $d - 1,
+                    };
+
+                    assert_eq!(raw.det_exact(), Err(expected));
+                    assert_eq!(raw.det_exact_f64(), Err(expected));
+                    assert_eq!(raw.det_sign_exact(), Err(expected));
+                    assert_eq!(raw.solve_exact(rhs), Err(expected));
+                    assert_eq!(raw.solve_exact_f64(rhs), Err(expected));
+                }
+
+                #[test]
+                fn [<public_exact_solve_methods_revalidate_unchecked_rhs_storage_ $d d>]() {
+                    let matrix = Matrix::<$d>::identity();
+                    let mut rhs = [1.0; $d];
+                    rhs[$d - 1] = f64::INFINITY;
+                    let rhs = Vector::<$d>::new_unchecked(rhs);
+                    let expected = LaError::NonFinite {
+                        row: None,
+                        col: $d - 1,
+                    };
+
+                    assert_eq!(matrix.solve_exact(rhs), Err(expected));
+                    assert_eq!(matrix.solve_exact_f64(rhs), Err(expected));
+                }
+            }
+        };
+    }
+
+    gen_public_exact_revalidation_tests!(2);
+    gen_public_exact_revalidation_tests!(3);
+    gen_public_exact_revalidation_tests!(4);
+    gen_public_exact_revalidation_tests!(5);
 
     macro_rules! gen_det_exact_tests {
         ($d:literal) => {
@@ -1289,7 +1346,7 @@ mod tests {
 
     #[test]
     fn bareiss_det_int_d0() {
-        let m = FiniteMatrix::new(Matrix::<0>::zero());
+        let m = FiniteMatrix::new_unchecked(Matrix::<0>::zero());
         let (det, exp) = bareiss_det_int_finite(&m).unwrap();
         assert_eq!(det, BigInt::from(1));
         assert_eq!(exp, 0);
@@ -1310,7 +1367,7 @@ mod tests {
             (0.5, 1, -1),   // 0.5  =  1 × 2^(-1)
         ];
         for &(input, expected_det_int, expected_exp) in cases {
-            let m = FiniteMatrix::new(Matrix::<1>::from_rows([[input]]));
+            let m = FiniteMatrix::new_unchecked(Matrix::<1>::from_rows([[input]]));
             let (det, exp) = bareiss_det_int_finite(&m).unwrap();
             assert_eq!(
                 det,
@@ -1324,7 +1381,7 @@ mod tests {
     #[test]
     fn bareiss_det_int_d2_known() {
         // det([[1,2],[3,4]]) = -2
-        let m = FiniteMatrix::new(Matrix::<2>::from_rows([[1.0, 2.0], [3.0, 4.0]]));
+        let m = FiniteMatrix::new_unchecked(Matrix::<2>::from_rows([[1.0, 2.0], [3.0, 4.0]]));
         let (det_int, total_exp) = bareiss_det_int_finite(&m).unwrap();
         // Reconstruct and verify.
         let det = bigint_exp_to_bigrational(det_int, total_exp);
@@ -1333,7 +1390,7 @@ mod tests {
 
     #[test]
     fn bareiss_det_int_all_zeros() {
-        let m = FiniteMatrix::new(Matrix::<3>::zero());
+        let m = FiniteMatrix::new_unchecked(Matrix::<3>::zero());
         let (det, _) = bareiss_det_int_finite(&m).unwrap();
         assert_eq!(det, BigInt::from(0));
     }
@@ -1341,7 +1398,7 @@ mod tests {
     #[test]
     fn bareiss_det_int_sign_matches_det_sign_exact() {
         // The sign of det_int should match det_sign_exact for various matrices.
-        let m = FiniteMatrix::new(Matrix::<3>::from_rows([
+        let m = FiniteMatrix::new_unchecked(Matrix::<3>::from_rows([
             [0.0, 1.0, 0.0],
             [1.0, 0.0, 0.0],
             [0.0, 0.0, 1.0],
@@ -1354,7 +1411,7 @@ mod tests {
     fn bareiss_det_int_fractional_entries() {
         // Entries with negative exponents: 0.5 = 1×2^(-1), 0.25 = 1×2^(-2).
         // det([[0.5, 0.25], [1.0, 1.0]]) = 0.5×1.0 − 0.25×1.0 = 0.25
-        let m = FiniteMatrix::new(Matrix::<2>::from_rows([[0.5, 0.25], [1.0, 1.0]]));
+        let m = FiniteMatrix::new_unchecked(Matrix::<2>::from_rows([[0.5, 0.25], [1.0, 1.0]]));
         let (det_int, total_exp) = bareiss_det_int_finite(&m).unwrap();
         let det = bigint_exp_to_bigrational(det_int, total_exp);
         assert_eq!(det, BigRational::new(BigInt::from(1), BigInt::from(4)));
@@ -1363,7 +1420,7 @@ mod tests {
     #[test]
     fn bareiss_det_int_d3_with_pivoting() {
         // Zero on diagonal → exercises pivot swap inside bareiss_det_int.
-        let m = FiniteMatrix::new(Matrix::<3>::from_rows([
+        let m = FiniteMatrix::new_unchecked(Matrix::<3>::from_rows([
             [0.0, 1.0, 0.0],
             [1.0, 0.0, 0.0],
             [0.0, 0.0, 1.0],
@@ -1379,7 +1436,7 @@ mod tests {
             paste! {
                 #[test]
                 fn [<bareiss_det_int_identity_ $d d>]() {
-                    let m = FiniteMatrix::new(Matrix::<$d>::identity());
+                    let m = FiniteMatrix::new_unchecked(Matrix::<$d>::identity());
                     let (det_int, total_exp) = bareiss_det_int_finite(&m).unwrap();
                     let det = bigint_exp_to_bigrational(det_int, total_exp);
                     assert_eq!(det, BigRational::from_integer(BigInt::from(1)));

--- a/src/ldlt.rs
+++ b/src/ldlt.rs
@@ -187,13 +187,18 @@ impl<const D: usize> Ldlt<D> {
     /// ```
     ///
     /// # Errors
-    /// Returns [`LaError::NonFinite`] if a computed substitution intermediate
-    /// overflows to NaN or infinity. Raw non-finite right-hand sides are rejected
-    /// by [`Vector::try_new`](crate::Vector::try_new) before a [`Vector`] can be
-    /// passed to this method.
+    /// Returns [`LaError::NonFinite`] if the right-hand side contains
+    /// NaN/infinity or a computed substitution intermediate overflows to NaN or
+    /// infinity. The right-hand side is revalidated at this boundary before
+    /// entering substitution; public callers normally encounter the same
+    /// rejection earlier through [`Vector::try_new`](crate::Vector::try_new).
     #[inline]
     pub const fn solve_vec(&self, b: Vector<D>) -> Result<Vector<D>, LaError> {
-        match self.solve_finite_vec(FiniteVector::new(b)) {
+        let b = match FiniteVector::new(b) {
+            Ok(b) => b,
+            Err(err) => return Err(err),
+        };
+        match self.solve_finite_vec(b) {
             Ok(x) => Ok(x.into_vector()),
             Err(err) => Err(err),
         }
@@ -264,7 +269,7 @@ impl<const D: usize> Ldlt<D> {
             ii += 1;
         }
 
-        Ok(FiniteVector::new(Vector::new_unchecked(x)))
+        Ok(FiniteVector::new_unchecked(Vector::new_unchecked(x)))
     }
 }
 
@@ -374,7 +379,10 @@ mod tests {
     #[test]
     fn solve_2x2_known_spd() {
         let a = Matrix::<2>::from_rows(black_box([[4.0, 2.0], [2.0, 3.0]]));
-        let ldlt = FiniteMatrix::new(a).ldlt(DEFAULT_SINGULAR_TOL).unwrap();
+        let ldlt = FiniteMatrix::new(a)
+            .unwrap()
+            .ldlt(DEFAULT_SINGULAR_TOL)
+            .unwrap();
 
         let b = Vector::<2>::new(black_box([1.0, 2.0]));
         let x = ldlt.solve_vec(b).unwrap().into_array();
@@ -584,7 +592,7 @@ mod tests {
         ($d:literal) => {
             paste! {
                 /// Raw non-finite right-hand sides are rejected before a
-                /// `Vector` can be passed into `solve_vec`.
+                /// public caller can construct a `Vector`.
                 #[test]
                 fn [<solve_vec_rhs_boundary_rejects_non_finite_ $d d>]() {
                     let mut rhs = [1.0; $d];
@@ -592,6 +600,22 @@ mod tests {
 
                     assert_eq!(
                         Vector::<$d>::try_new(rhs),
+                        Err(LaError::NonFinite {
+                            row: None,
+                            col: $d - 1,
+                        })
+                    );
+                }
+
+                #[test]
+                fn [<solve_vec_revalidates_unchecked_rhs_storage_ $d d>]() {
+                    let ldlt = Matrix::<$d>::identity().ldlt(DEFAULT_SINGULAR_TOL).unwrap();
+                    let mut rhs = [1.0; $d];
+                    rhs[$d - 1] = f64::NAN;
+                    let rhs = Vector::<$d>::new_unchecked(rhs);
+
+                    assert_eq!(
+                        ldlt.solve_vec(rhs),
                         Err(LaError::NonFinite {
                             row: None,
                             col: $d - 1,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,8 +127,8 @@ const EPS: f64 = f64::EPSILON; // 2^-52
 ///
 /// Prefer [`Matrix::det_errbound`](crate::Matrix::det_errbound) unless
 /// you already have the absolute-Leibniz sum available; see
-/// [`Matrix::det_sign_exact`](crate::Matrix::det_sign_exact) (under the
-/// `exact` feature) for the reference adaptive-precision filter.
+/// `Matrix::det_sign_exact` (under the `exact` feature) for the reference
+/// adaptive-precision filter.
 ///
 /// # Example
 /// ```
@@ -706,13 +706,12 @@ macro_rules! try_with_stack_matrix {
 /// It also re-exports [`MAX_STACK_MATRIX_DISPATCH_DIM`] and
 /// [`try_with_stack_matrix!`] for runtime-to-const matrix dispatch.
 ///
-/// When the `exact` feature is enabled, [`BigInt`] and [`BigRational`]
-/// are also re-exported so callers can construct exact values (e.g. as
-/// the expected result of `Matrix::det_exact`) without adding
-/// `num-bigint` / `num-rational` to their own dependencies.  The most
-/// commonly needed `num-traits` items are re-exported alongside them:
-/// [`FromPrimitive`] for `BigRational::from_f64` / `from_i64`,
-/// [`ToPrimitive`] for `BigRational::to_f64` / `to_i64`, and [`Signed`]
+/// When the `exact` feature is enabled, `BigInt` and `BigRational` are also
+/// re-exported so callers can construct exact values (e.g. as the expected
+/// result of `Matrix::det_exact`) without adding `num-bigint` / `num-rational`
+/// to their own dependencies. The most commonly needed `num-traits` items are
+/// re-exported alongside them: `FromPrimitive` for `BigRational::from_f64` /
+/// `from_i64`, `ToPrimitive` for `BigRational::to_f64` / `to_i64`, and `Signed`
 /// for `.is_positive()` / `.is_negative()` / `.abs()`.
 pub mod prelude {
     pub use crate::{

--- a/src/lu.rs
+++ b/src/lu.rs
@@ -139,13 +139,18 @@ impl<const D: usize> Lu<D> {
     /// ```
     ///
     /// # Errors
-    /// Returns [`LaError::NonFinite`] if a computed substitution intermediate
-    /// overflows to NaN or infinity. Raw non-finite right-hand sides are rejected
-    /// by [`Vector::try_new`](crate::Vector::try_new) before a [`Vector`] can be
-    /// passed to this method.
+    /// Returns [`LaError::NonFinite`] if the right-hand side contains
+    /// NaN/infinity or a computed substitution intermediate overflows to NaN or
+    /// infinity. The right-hand side is revalidated at this boundary before
+    /// entering substitution; public callers normally encounter the same
+    /// rejection earlier through [`Vector::try_new`](crate::Vector::try_new).
     #[inline]
     pub const fn solve_vec(&self, b: Vector<D>) -> Result<Vector<D>, LaError> {
-        match self.solve_finite_vec(FiniteVector::new(b)) {
+        let b = match FiniteVector::new(b) {
+            Ok(b) => b,
+            Err(err) => return Err(err),
+        };
+        match self.solve_finite_vec(b) {
             Ok(x) => Ok(x.into_vector()),
             Err(err) => Err(err),
         }
@@ -217,7 +222,7 @@ impl<const D: usize> Lu<D> {
             ii += 1;
         }
 
-        Ok(FiniteVector::new(Vector::new_unchecked(x)))
+        Ok(FiniteVector::new_unchecked(Vector::new_unchecked(x)))
     }
 
     /// Determinant of the original matrix.
@@ -421,7 +426,7 @@ mod tests {
     #[test]
     fn solve_1x1() {
         let a = Matrix::<1>::from_rows(black_box([[2.0]]));
-        let lu = FiniteMatrix::new(a).lu(DEFAULT_PIVOT_TOL).unwrap();
+        let lu = FiniteMatrix::new(a).unwrap().lu(DEFAULT_PIVOT_TOL).unwrap();
 
         let b = Vector::<1>::new(black_box([6.0]));
         let solve_fn: fn(&Lu<1>, Vector<1>) -> Result<Vector<1>, LaError> =
@@ -436,7 +441,7 @@ mod tests {
     #[test]
     fn solve_2x2_basic() {
         let a = Matrix::<2>::from_rows(black_box([[1.0, 2.0], [3.0, 4.0]]));
-        let lu = FiniteMatrix::new(a).lu(DEFAULT_PIVOT_TOL).unwrap();
+        let lu = FiniteMatrix::new(a).unwrap().lu(DEFAULT_PIVOT_TOL).unwrap();
         let b = Vector::<2>::new(black_box([5.0, 11.0]));
 
         let solve_fn: fn(&Lu<2>, Vector<2>) -> Result<Vector<2>, LaError> =
@@ -608,7 +613,7 @@ mod tests {
         ($d:literal) => {
             paste! {
                 /// Raw non-finite right-hand sides are rejected before a
-                /// `Vector` can be passed into `solve_vec`.
+                /// public caller can construct a `Vector`.
                 #[test]
                 fn [<solve_vec_rhs_boundary_rejects_non_finite_ $d d>]() {
                     let mut rhs = [1.0; $d];
@@ -616,6 +621,22 @@ mod tests {
 
                     assert_eq!(
                         Vector::<$d>::try_new(rhs),
+                        Err(LaError::NonFinite {
+                            row: None,
+                            col: $d - 1,
+                        })
+                    );
+                }
+
+                #[test]
+                fn [<solve_vec_revalidates_unchecked_rhs_storage_ $d d>]() {
+                    let lu = Matrix::<$d>::identity().lu(DEFAULT_PIVOT_TOL).unwrap();
+                    let mut rhs = [1.0; $d];
+                    rhs[$d - 1] = f64::NAN;
+                    let rhs = Vector::<$d>::new_unchecked(rhs);
+
+                    assert_eq!(
+                        lu.solve_vec(rhs),
                         Err(LaError::NonFinite {
                             row: None,
                             col: $d - 1,

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -15,7 +15,7 @@ pub struct Matrix<const D: usize> {
 
 /// Fixed-size square matrix whose stored entries are all finite.
 ///
-/// This proof-carrying wrapper makes the finite invariant explicit for internal
+/// This proof-bearing wrapper makes the finite invariant explicit for internal
 /// algorithms that should not repeatedly check stored entries for NaN or
 /// infinity.
 #[must_use]
@@ -26,11 +26,28 @@ pub(crate) struct FiniteMatrix<const D: usize> {
 }
 
 impl<const D: usize> FiniteMatrix<D> {
-    /// Wrap an already-finite matrix for algorithms that carry the invariant
-    /// explicitly.
+    /// Construct a finite matrix without checking the invariant.
+    ///
+    /// This crate-internal escape hatch is only for paths with a local proof
+    /// that every stored entry is finite.
     #[inline]
-    pub const fn new(matrix: Matrix<D>) -> Self {
+    pub(crate) const fn new_unchecked(matrix: Matrix<D>) -> Self {
         Self { matrix }
+    }
+
+    /// Validate a matrix and wrap it for algorithms that carry the finite
+    /// invariant explicitly.
+    ///
+    /// # Errors
+    /// Returns [`LaError::NonFinite`] with matrix coordinates for the first
+    /// stored NaN or infinity in row-major order.
+    #[inline]
+    pub(crate) const fn new(matrix: Matrix<D>) -> Result<Self, LaError> {
+        if let Some((row, col)) = Matrix::<D>::first_non_finite_cell_in(&matrix.rows) {
+            Err(LaError::non_finite_cell(row, col))
+        } else {
+            Ok(Self::new_unchecked(matrix))
+        }
     }
 
     /// Validate raw row-major storage and construct a finite matrix.
@@ -38,22 +55,22 @@ impl<const D: usize> FiniteMatrix<D> {
     /// Returns [`LaError::NonFinite`] with matrix coordinates for the first
     /// offending entry in row-major order when `rows` contains NaN or infinity.
     #[inline]
-    pub const fn from_rows(rows: [[f64; D]; D]) -> Result<Self, LaError> {
+    pub(crate) const fn from_rows(rows: [[f64; D]; D]) -> Result<Self, LaError> {
         match Matrix::try_from_rows(rows) {
-            Ok(matrix) => Ok(Self::new(matrix)),
+            Ok(matrix) => Ok(Self::new_unchecked(matrix)),
             Err(err) => Err(err),
         }
     }
 
     /// All-zeros finite matrix.
     #[inline]
-    pub const fn zero() -> Self {
-        Self::new(Matrix::zero())
+    pub(crate) const fn zero() -> Self {
+        Self::new_unchecked(Matrix::zero())
     }
 
     /// Consume the wrapper and return the underlying raw matrix.
     #[inline]
-    pub const fn into_matrix(self) -> Matrix<D> {
+    pub(crate) const fn into_matrix(self) -> Matrix<D> {
         self.matrix
     }
 
@@ -72,7 +89,7 @@ impl<const D: usize> FiniteMatrix<D> {
     /// # Errors
     /// Returns [`LaError::NonFinite`] when a row sum overflows to NaN or infinity.
     #[inline]
-    pub const fn inf_norm(&self) -> Result<f64, LaError> {
+    pub(crate) const fn inf_norm(&self) -> Result<f64, LaError> {
         let mut max_row_sum: f64 = 0.0;
 
         let mut r = 0;
@@ -103,7 +120,7 @@ impl<const D: usize> FiniteMatrix<D> {
     /// Returns [`LaError::NonFinite`] when computing the scaled symmetry tolerance
     /// overflows to NaN or infinity.
     #[inline]
-    pub fn is_symmetric(&self, rel_tol: Tolerance) -> Result<bool, LaError> {
+    pub(crate) fn is_symmetric(&self, rel_tol: Tolerance) -> Result<bool, LaError> {
         Ok(self.first_asymmetry(rel_tol)?.is_none())
     }
 
@@ -113,7 +130,10 @@ impl<const D: usize> FiniteMatrix<D> {
     /// Returns [`LaError::NonFinite`] when computing the scaled symmetry tolerance
     /// overflows to NaN or infinity.
     #[inline]
-    pub fn first_asymmetry(&self, rel_tol: Tolerance) -> Result<Option<(usize, usize)>, LaError> {
+    pub(crate) fn first_asymmetry(
+        &self,
+        rel_tol: Tolerance,
+    ) -> Result<Option<(usize, usize)>, LaError> {
         let eps = self.symmetry_epsilon(rel_tol)?;
         for r in 0..D {
             for c in (r + 1)..D {
@@ -158,7 +178,7 @@ impl<const D: usize> FiniteMatrix<D> {
     /// Returns [`LaError::Singular`] for an unusable pivot, or
     /// [`LaError::NonFinite`] if elimination computes a non-finite intermediate.
     #[inline]
-    pub fn lu(self, tol: Tolerance) -> Result<Lu<D>, LaError> {
+    pub(crate) fn lu(self, tol: Tolerance) -> Result<Lu<D>, LaError> {
         Lu::factor_finite(self, tol)
     }
 
@@ -170,7 +190,7 @@ impl<const D: usize> FiniteMatrix<D> {
     /// [`LaError::Singular`] for a zero or too-small non-negative diagonal, or
     /// [`LaError::NonFinite`] if factorization computes a non-finite intermediate.
     #[inline]
-    pub fn ldlt(self, tol: Tolerance) -> Result<Ldlt<D>, LaError> {
+    pub(crate) fn ldlt(self, tol: Tolerance) -> Result<Ldlt<D>, LaError> {
         Ldlt::factor_symmetric(SymmetricMatrix::try_new(self)?, tol)
     }
 
@@ -180,7 +200,7 @@ impl<const D: usize> FiniteMatrix<D> {
     /// Returns [`LaError::NonFinite`] when the closed-form determinant overflows
     /// to NaN or infinity.
     #[inline]
-    pub const fn det_direct(&self) -> Result<Option<f64>, LaError> {
+    pub(crate) const fn det_direct(&self) -> Result<Option<f64>, LaError> {
         match D {
             0 => Ok(Some(1.0)),
             1 => Self::computed_scalar_result(Some(self.matrix.rows[0][0])),
@@ -239,7 +259,7 @@ impl<const D: usize> FiniteMatrix<D> {
     /// Returns [`LaError::NonFinite`] if a computed determinant or LU fallback
     /// intermediate overflows to NaN or infinity.
     #[inline]
-    pub fn det(self) -> Result<f64, LaError> {
+    pub(crate) fn det(self) -> Result<f64, LaError> {
         if let Some(d) = self.det_direct()? {
             return Ok(d);
         }
@@ -256,7 +276,7 @@ impl<const D: usize> FiniteMatrix<D> {
     /// Returns [`LaError::NonFinite`] when the bound computation overflows to NaN
     /// or infinity.
     #[inline]
-    pub const fn det_errbound(&self) -> Result<Option<f64>, LaError> {
+    pub(crate) const fn det_errbound(&self) -> Result<Option<f64>, LaError> {
         match D {
             0 | 1 => Self::computed_scalar_result(Some(0.0)),
             2 => {
@@ -338,11 +358,7 @@ impl<const D: usize> TryFrom<Matrix<D>> for FiniteMatrix<D> {
 
     #[inline]
     fn try_from(value: Matrix<D>) -> Result<Self, Self::Error> {
-        if let Some((row, col)) = Matrix::<D>::first_non_finite_cell_in(&value.rows) {
-            Err(LaError::non_finite_cell(row, col))
-        } else {
-            Ok(Self::new(value))
-        }
+        Self::new(value)
     }
 }
 
@@ -416,9 +432,9 @@ impl<const D: usize> Matrix<D> {
 
     /// Try to create a finite matrix from row-major storage.
     ///
-    /// This is the public raw-storage boundary for matrices. Once construction
-    /// succeeds, methods such as [`lu`](Self::lu), [`ldlt`](Self::ldlt), and
-    /// [`det`](Self::det) can rely on finite stored entries.
+    /// This is the public raw-storage boundary for matrices. Public compute
+    /// methods parse stored rows into crate-internal proof-bearing types before
+    /// arithmetic, including when crate-internal unchecked storage exists.
     ///
     /// # Examples
     /// ```
@@ -651,11 +667,14 @@ impl<const D: usize> Matrix<D> {
     /// ```
     ///
     /// # Errors
-    /// Returns [`LaError::NonFinite`] when a row sum overflows to NaN or
-    /// infinity.
+    /// Returns [`LaError::NonFinite`] when stored entries are NaN/infinity or a
+    /// row sum overflows to NaN or infinity.
     #[inline]
     pub const fn inf_norm(&self) -> Result<f64, LaError> {
-        FiniteMatrix::new(*self).inf_norm()
+        match FiniteMatrix::new(*self) {
+            Ok(matrix) => matrix.inf_norm(),
+            Err(err) => Err(err),
+        }
     }
 
     /// Returns `true` if the matrix is symmetric within a relative tolerance.
@@ -697,11 +716,11 @@ impl<const D: usize> Matrix<D> {
     /// ```
     ///
     /// # Errors
-    /// Returns [`LaError::NonFinite`] when computing the scaled symmetry
-    /// tolerance overflows to NaN or infinity.
+    /// Returns [`LaError::NonFinite`] when stored entries are NaN/infinity or
+    /// computing the scaled symmetry tolerance overflows to NaN or infinity.
     #[inline]
     pub fn is_symmetric(&self, rel_tol: Tolerance) -> Result<bool, LaError> {
-        FiniteMatrix::new(*self).is_symmetric(rel_tol)
+        FiniteMatrix::new(*self)?.is_symmetric(rel_tol)
     }
 
     /// Returns the indices `(r, c)` (with `r < c`) of the first off-diagonal
@@ -742,11 +761,11 @@ impl<const D: usize> Matrix<D> {
     /// ```
     ///
     /// # Errors
-    /// Returns [`LaError::NonFinite`] when computing the scaled symmetry
-    /// tolerance overflows to NaN or infinity.
+    /// Returns [`LaError::NonFinite`] when stored entries are NaN/infinity or
+    /// computing the scaled symmetry tolerance overflows to NaN or infinity.
     #[inline]
     pub fn first_asymmetry(&self, rel_tol: Tolerance) -> Result<Option<(usize, usize)>, LaError> {
-        FiniteMatrix::new(*self).first_asymmetry(rel_tol)
+        FiniteMatrix::new(*self)?.first_asymmetry(rel_tol)
     }
 
     /// Compute an LU decomposition with partial pivoting.
@@ -777,11 +796,12 @@ impl<const D: usize> Matrix<D> {
     /// # Errors
     /// Returns [`LaError::Singular`] if, for some column `k`, the largest-magnitude candidate pivot
     /// in that column satisfies `|pivot| <= tol` (so no numerically usable pivot exists).
-    /// Returns [`LaError::NonFinite`] if an elimination intermediate overflows
-    /// to NaN/∞ before it can be stored in the returned [`Lu`].
+    /// Returns [`LaError::NonFinite`] if stored entries are NaN/infinity or an
+    /// elimination intermediate overflows to NaN/∞ before it can be stored in
+    /// the returned [`Lu`].
     #[inline]
     pub fn lu(self, tol: Tolerance) -> Result<Lu<D>, LaError> {
-        FiniteMatrix::new(self).lu(tol)
+        FiniteMatrix::new(self)?.lu(tol)
     }
 
     /// Compute an LDLT factorization (`A = L D Lᵀ`) without pivoting.
@@ -830,12 +850,12 @@ impl<const D: usize> Matrix<D> {
     /// diagonal entry `d = D[k,k]` is negative.
     /// Returns [`LaError::Singular`] if `0 <= d <= tol`, treating PSD degeneracy
     /// as singular/degenerate.
-    /// Returns [`LaError::NonFinite`] if factorization computes a non-finite
-    /// intermediate.
+    /// Returns [`LaError::NonFinite`] if stored entries are NaN/infinity or
+    /// factorization computes a non-finite intermediate.
     /// Returns [`LaError::Asymmetric`] if the input matrix is not symmetric.
     #[inline]
     pub fn ldlt(self, tol: Tolerance) -> Result<Ldlt<D>, LaError> {
-        FiniteMatrix::new(self).ldlt(tol)
+        FiniteMatrix::new(self)?.ldlt(tol)
     }
 
     /// Return the first non-finite stored cell in row-major order.
@@ -882,11 +902,14 @@ impl<const D: usize> Matrix<D> {
     /// ```
     ///
     /// # Errors
-    /// Returns [`LaError::NonFinite`] when the closed-form determinant overflows
-    /// to NaN or infinity.
+    /// Returns [`LaError::NonFinite`] when stored entries are NaN/infinity or
+    /// the closed-form determinant overflows to NaN or infinity.
     #[inline]
     pub const fn det_direct(&self) -> Result<Option<f64>, LaError> {
-        FiniteMatrix::new(*self).det_direct()
+        match FiniteMatrix::new(*self) {
+            Ok(matrix) => matrix.det_direct(),
+            Err(err) => Err(err),
+        }
     }
 
     /// Floating-point determinant, using closed-form formulas for D ≤ 4 and
@@ -917,12 +940,12 @@ impl<const D: usize> Matrix<D> {
     /// ```
     ///
     /// # Errors
-    /// Returns [`LaError::NonFinite`] if the LU fallback computes a non-finite
-    /// factorization cell, or if the determinant product overflows to NaN or
-    /// infinity.
+    /// Returns [`LaError::NonFinite`] if stored entries are NaN/infinity, the
+    /// LU fallback computes a non-finite factorization cell, or the determinant
+    /// product overflows to NaN or infinity.
     #[inline]
     pub fn det(self) -> Result<f64, LaError> {
-        FiniteMatrix::new(self).det()
+        FiniteMatrix::new(self)?.det()
     }
 
     /// Conservative absolute error bound for `det_direct()`.
@@ -986,11 +1009,14 @@ impl<const D: usize> Matrix<D> {
     /// ```
     ///
     /// # Errors
-    /// Returns [`LaError::NonFinite`] when the bound computation overflows to
-    /// NaN or infinity.
+    /// Returns [`LaError::NonFinite`] when stored entries are NaN/infinity or
+    /// the bound computation overflows to NaN or infinity.
     #[inline]
     pub const fn det_errbound(&self) -> Result<Option<f64>, LaError> {
-        FiniteMatrix::new(*self).det_errbound()
+        match FiniteMatrix::new(*self) {
+            Ok(matrix) => matrix.det_errbound(),
+            Err(err) => Err(err),
+        }
     }
 }
 
@@ -1249,7 +1275,7 @@ mod tests {
 
                 #[test]
                 fn [<finite_matrix_lu_and_ldlt_accept_finite_rhs_ $d d>]() {
-                    let finite = FiniteMatrix::<$d>::new(Matrix::<$d>::identity());
+                    let finite = FiniteMatrix::<$d>::new(Matrix::<$d>::identity()).unwrap();
                     let rhs = {
                         let mut arr = [0.0f64; $d];
                         let values = [1.0f64, 2.0, 3.0, 4.0, 5.0];
@@ -1280,6 +1306,61 @@ mod tests {
     gen_public_api_matrix_tests!(3);
     gen_public_api_matrix_tests!(4);
     gen_public_api_matrix_tests!(5);
+
+    macro_rules! gen_public_matrix_revalidation_tests {
+        ($d:literal) => {
+            paste! {
+                #[test]
+                fn [<public_matrix_compute_methods_revalidate_unchecked_storage_ $d d>]() {
+                    let mut rows = [[0.0f64; $d]; $d];
+                    for i in 0..$d {
+                        rows[i][i] = 1.0;
+                    }
+                    rows[0][$d - 1] = f64::NAN;
+                    let raw = Matrix::<$d>::from_rows_unchecked(rows);
+                    let expected = LaError::NonFinite {
+                        row: Some(0),
+                        col: $d - 1,
+                    };
+
+                    assert_eq!(raw.inf_norm(), Err(expected));
+                    assert_eq!(
+                        raw.is_symmetric(Tolerance::new(0.0).unwrap()),
+                        Err(expected)
+                    );
+                    assert_eq!(
+                        raw.first_asymmetry(Tolerance::new(0.0).unwrap()),
+                        Err(expected)
+                    );
+                    assert_eq!(raw.lu(DEFAULT_PIVOT_TOL), Err(expected));
+                    assert_eq!(raw.ldlt(DEFAULT_PIVOT_TOL), Err(expected));
+                    assert_eq!(raw.det_direct(), Err(expected));
+                    assert_eq!(raw.det(), Err(expected));
+                    assert_eq!(raw.det_errbound(), Err(expected));
+                }
+            }
+        };
+    }
+
+    gen_public_matrix_revalidation_tests!(2);
+    gen_public_matrix_revalidation_tests!(3);
+    gen_public_matrix_revalidation_tests!(4);
+    gen_public_matrix_revalidation_tests!(5);
+
+    #[test]
+    fn public_matrix_fast_none_paths_revalidate_unchecked_storage() {
+        let mut rows = [[1.0f64; 5]; 5];
+        rows[4][1] = f64::INFINITY;
+        let raw = Matrix::<5>::from_rows_unchecked(rows);
+
+        let expected = Err(LaError::NonFinite {
+            row: Some(4),
+            col: 1,
+        });
+
+        assert_eq!(raw.det_direct(), expected);
+        assert_eq!(raw.det_errbound(), expected);
+    }
 
     // === det_direct tests ===
 
@@ -1892,7 +1973,7 @@ mod tests {
 
                     assert_eq!(
                         Matrix::<$d>::try_from_rows(rows)
-                            .map(FiniteMatrix::new)
+                            .and_then(FiniteMatrix::new)
                             .and_then(SymmetricMatrix::try_new),
                         Err(LaError::Asymmetric {
                             row: 0,
@@ -1924,7 +2005,7 @@ mod tests {
     #[test]
     fn symmetric_matrix_into_matrix_roundtrips_storage_internally() {
         let a = Matrix::<2>::from_rows([[2.0, 1.0], [1.0, 3.0]]);
-        let symmetric = SymmetricMatrix::try_new(FiniteMatrix::new(a)).unwrap();
+        let symmetric = SymmetricMatrix::try_new(FiniteMatrix::new(a).unwrap()).unwrap();
 
         assert_eq!(symmetric.into_matrix(), a);
     }

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -11,7 +11,7 @@ pub struct Vector<const D: usize> {
 
 /// Fixed-size vector whose stored entries are all finite.
 ///
-/// This proof-carrying wrapper makes the finite invariant explicit for internal
+/// This proof-bearing wrapper makes the finite invariant explicit for internal
 /// algorithms that should not rediscover that no stored entry is NaN or
 /// infinite.
 #[must_use]
@@ -22,11 +22,31 @@ pub(crate) struct FiniteVector<const D: usize> {
 }
 
 impl<const D: usize> FiniteVector<D> {
-    /// Wrap an already-finite vector for algorithms that carry the invariant
-    /// explicitly.
+    /// Construct a finite vector without checking the invariant.
+    ///
+    /// This crate-internal escape hatch is only for paths with a local proof
+    /// that every stored entry is finite.
     #[inline]
-    pub const fn new(vector: Vector<D>) -> Self {
+    pub(crate) const fn new_unchecked(vector: Vector<D>) -> Self {
         Self { vector }
+    }
+
+    /// Validate a vector and wrap it for algorithms that carry the finite
+    /// invariant explicitly.
+    ///
+    /// # Errors
+    /// Returns [`LaError::NonFinite`] with `row: None` and the first offending
+    /// entry index when `vector` contains NaN or infinity.
+    #[inline]
+    pub(crate) const fn new(vector: Vector<D>) -> Result<Self, LaError> {
+        let mut i = 0;
+        while i < D {
+            if !vector.data[i].is_finite() {
+                return Err(LaError::non_finite_at(i));
+            }
+            i += 1;
+        }
+        Ok(Self::new_unchecked(vector))
     }
 
     /// Validate raw vector storage and construct a finite vector.
@@ -34,22 +54,22 @@ impl<const D: usize> FiniteVector<D> {
     /// Returns [`LaError::NonFinite`] with `row: None` and the first offending
     /// entry index when `data` contains NaN or infinity.
     #[inline]
-    pub const fn from_array(data: [f64; D]) -> Result<Self, LaError> {
+    pub(crate) const fn from_array(data: [f64; D]) -> Result<Self, LaError> {
         match Vector::try_new(data) {
-            Ok(vector) => Ok(Self::new(vector)),
+            Ok(vector) => Ok(Self::new_unchecked(vector)),
             Err(err) => Err(err),
         }
     }
 
     /// All-zeros finite vector.
     #[inline]
-    pub const fn zero() -> Self {
-        Self::new(Vector::zero())
+    pub(crate) const fn zero() -> Self {
+        Self::new_unchecked(Vector::zero())
     }
 
     /// Consume the wrapper and return the underlying raw vector.
     #[inline]
-    pub const fn into_vector(self) -> Vector<D> {
+    pub(crate) const fn into_vector(self) -> Vector<D> {
         self.vector
     }
 
@@ -63,8 +83,55 @@ impl<const D: usize> FiniteVector<D> {
     /// Consume and return the backing array.
     #[inline]
     #[must_use]
-    pub const fn into_array(self) -> [f64; D] {
+    pub(crate) const fn into_array(self) -> [f64; D] {
         self.vector.into_array()
+    }
+
+    /// Dot product for already finite vectors.
+    ///
+    /// Stored entries are known finite, so this path only checks whether the
+    /// accumulation overflows to NaN or infinity.
+    ///
+    /// # Errors
+    /// Returns [`LaError::NonFinite`] when the accumulated dot product overflows
+    /// to NaN or infinity.
+    #[inline]
+    pub(crate) const fn dot(self, other: Self) -> Result<f64, LaError> {
+        let lhs = self.vector.data;
+        let rhs = other.vector.data;
+        let mut acc = 0.0;
+        let mut i = 0;
+        while i < D {
+            acc = lhs[i].mul_add(rhs[i], acc);
+            if !acc.is_finite() {
+                return Err(LaError::non_finite_at(i));
+            }
+            i += 1;
+        }
+        Ok(acc)
+    }
+
+    /// Squared Euclidean norm for an already finite vector.
+    ///
+    /// Stored entries are known finite, so this path only checks whether the
+    /// accumulation overflows to NaN or infinity.
+    ///
+    /// # Errors
+    /// Returns [`LaError::NonFinite`] when the accumulated norm overflows to NaN
+    /// or infinity.
+    #[inline]
+    pub(crate) const fn norm2_sq(self) -> Result<f64, LaError> {
+        let data = self.vector.data;
+        let mut acc = 0.0;
+        let mut i = 0;
+        while i < D {
+            acc = data[i].mul_add(data[i], acc);
+            if !acc.is_finite() {
+                return Err(LaError::non_finite_at(i));
+            }
+            i += 1;
+        }
+        Ok(acc)
     }
 }
 
@@ -87,14 +154,7 @@ impl<const D: usize> TryFrom<Vector<D>> for FiniteVector<D> {
 
     #[inline]
     fn try_from(value: Vector<D>) -> Result<Self, Self::Error> {
-        let mut i = 0;
-        while i < D {
-            if !value.data[i].is_finite() {
-                return Err(LaError::non_finite_at(i));
-            }
-            i += 1;
-        }
-        Ok(Self::new(value))
+        Self::new(value)
     }
 }
 
@@ -120,9 +180,9 @@ impl<const D: usize> Vector<D> {
 
     /// Try to create a finite vector from a backing array.
     ///
-    /// This is the public raw-storage boundary for vectors. Once construction
-    /// succeeds, methods such as [`dot`](Self::dot) and [`norm2_sq`](Self::norm2_sq)
-    /// do not need to rediscover that stored entries are finite.
+    /// This is the public raw-storage boundary for vectors. Public compute
+    /// methods parse stored entries into crate-internal proof-bearing types
+    /// before arithmetic, including when crate-internal unchecked storage exists.
     ///
     /// # Examples
     /// ```
@@ -214,9 +274,10 @@ impl<const D: usize> Vector<D> {
     ///
     /// Terms are accumulated in `f64` using [`f64::mul_add`] at each index.
     /// Intermediate rounding occurs, and this method does not provide a
-    /// certified absolute rounding bound for the returned dot product.  The
-    /// stored entries are finite by construction, so the returned [`Result`]
-    /// only reports non-finite accumulation.
+    /// certified absolute rounding bound for the returned dot product. Raw
+    /// storage is parsed into the crate-internal finite-vector proof before
+    /// accumulation, so internally unchecked vectors are rejected before
+    /// arithmetic starts.
     ///
     /// # Examples
     /// ```
@@ -231,20 +292,19 @@ impl<const D: usize> Vector<D> {
     /// ```
     ///
     /// # Errors
-    /// Returns [`LaError::NonFinite`] when the accumulated dot product overflows
-    /// to NaN or infinity.
+    /// Returns [`LaError::NonFinite`] when either input contains NaN/infinity or
+    /// the accumulated dot product overflows to NaN or infinity.
     #[inline]
     pub const fn dot(self, other: Self) -> Result<f64, LaError> {
-        let mut acc = 0.0;
-        let mut i = 0;
-        while i < D {
-            acc = self.data[i].mul_add(other.data[i], acc);
-            if !acc.is_finite() {
-                return Err(LaError::non_finite_at(i));
-            }
-            i += 1;
-        }
-        Ok(acc)
+        let lhs = match FiniteVector::new(self) {
+            Ok(lhs) => lhs,
+            Err(err) => return Err(err),
+        };
+        let rhs = match FiniteVector::new(other) {
+            Ok(rhs) => rhs,
+            Err(err) => return Err(err),
+        };
+        lhs.dot(rhs)
     }
 
     /// Squared Euclidean norm.
@@ -252,9 +312,9 @@ impl<const D: usize> Vector<D> {
     /// This is computed as `dot(self, self)`, so `norm2_sq` has the same
     /// `f64` [`mul_add`](f64::mul_add) accumulation behavior as [`dot`](Self::dot).
     /// Intermediate rounding occurs, and this method does not provide a
-    /// certified absolute rounding bound for the returned squared norm.  The
-    /// stored entries are finite by construction, so the returned [`Result`]
-    /// only reports non-finite accumulation.
+    /// certified absolute rounding bound for the returned squared norm. Raw
+    /// storage is parsed into the crate-internal finite-vector proof before
+    /// accumulation.
     ///
     /// # Examples
     /// ```
@@ -268,20 +328,14 @@ impl<const D: usize> Vector<D> {
     /// ```
     ///
     /// # Errors
-    /// Returns [`LaError::NonFinite`] when the accumulated norm overflows to NaN
-    /// or infinity.
+    /// Returns [`LaError::NonFinite`] when stored entries are NaN/infinity or
+    /// the accumulated norm overflows to NaN or infinity.
     #[inline]
     pub const fn norm2_sq(self) -> Result<f64, LaError> {
-        let mut acc = 0.0;
-        let mut i = 0;
-        while i < D {
-            acc = self.data[i].mul_add(self.data[i], acc);
-            if !acc.is_finite() {
-                return Err(LaError::non_finite_at(i));
-            }
-            i += 1;
+        match FiniteVector::new(self) {
+            Ok(vector) => vector.norm2_sq(),
+            Err(err) => Err(err),
         }
-        Ok(acc)
     }
 }
 
@@ -449,6 +503,38 @@ mod tests {
 
                     assert_eq!(a.dot(b), Err(LaError::NonFinite { row: None, col: 0 }));
                     assert_eq!(a.norm2_sq(), Err(LaError::NonFinite { row: None, col: 0 }));
+                }
+
+                #[test]
+                fn [<public_api_vector_methods_revalidate_unchecked_storage_ $d d>]() {
+                    let mut lhs_arr = [1.0f64; $d];
+                    lhs_arr[$d - 1] = f64::NAN;
+                    let lhs = Vector::<$d>::new_unchecked(lhs_arr);
+                    let valid = Vector::<$d>::new([1.0; $d]);
+
+                    assert_eq!(
+                        lhs.dot(valid),
+                        Err(LaError::NonFinite {
+                            row: None,
+                            col: $d - 1,
+                        })
+                    );
+                    assert_eq!(
+                        lhs.norm2_sq(),
+                        Err(LaError::NonFinite {
+                            row: None,
+                            col: $d - 1,
+                        })
+                    );
+
+                    let mut rhs_arr = [1.0f64; $d];
+                    rhs_arr[0] = f64::INFINITY;
+                    let rhs = Vector::<$d>::new_unchecked(rhs_arr);
+
+                    assert_eq!(
+                        valid.dot(rhs),
+                        Err(LaError::NonFinite { row: None, col: 0 })
+                    );
                 }
 
                 #[test]


### PR DESCRIPTION
- Parse Matrix and Vector storage into private finite proof-bearing types at public compute boundaries.
- Reject unchecked non-finite storage before LU, LDLT, determinant, norm, dot, and exact-arithmetic paths can proceed.
- Keep unchecked proof-wrapper constructors crate-private for internal paths with local finiteness proofs.
- Document the private proof-bearing invariant model in the API overview and roadmap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated README, CHANGELOG, and roadmap to clarify API validation requirements and behavior

* **Bug Fixes**
  * Enhanced validation at API boundaries to detect and report non-finite values (NaN/infinity) in matrices and vectors with specific error coordinates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->