### PR TITLE
feat(bench): add release performance comparison workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,51 @@
+# Contributing
+
+Thanks for helping improve `la-stack`. This crate is intentionally small and
+invariant-heavy, so changes should preserve mathematical correctness, API
+clarity, and the fixed-dimension stack-allocation model.
+
+## Workflow
+
+```bash
+cargo install just
+just setup        # install/verify dev tools + sync Python deps
+just check        # lint/validate (non-mutating)
+just fix          # apply auto-fixes (mutating)
+just ci           # lint + tests + examples + bench compile
+```
+
+The repository uses Rust-native tooling for documentation and config checks:
+`rumdl` for Markdown, `dprint` with `pretty_yaml` for YAML, `taplo` for TOML,
+and `typos` for spelling. GitHub Actions references are SHA-pinned, restricted
+to an explicit allowlist, and kept with readable version comments for review.
+
+CI runs `just ci` on Ubuntu, macOS, and Windows to keep platform coverage
+aligned with the local comprehensive validation path.
+
+For coverage commands and report locations, see [`docs/COVERAGE.md`](docs/COVERAGE.md).
+For benchmark methodology, see [`docs/BENCHMARKING.md`](docs/BENCHMARKING.md).
+For the full set of developer commands, run `just --list`.
+
+## AI-Assisted Development
+
+This repository contains an [`AGENTS.md`](AGENTS.md) file, which defines the
+canonical rules and invariants for AI coding assistants and autonomous agents
+working on this codebase.
+
+AI tools, including ChatGPT, Claude, CodeRabbit, Codex, KiloCode, and WARP, are
+expected to read and follow `AGENTS.md` when proposing or applying changes.
+
+Portions of this library were developed with the assistance of these tools:
+
+- [ChatGPT](https://openai.com/chatgpt)
+- [Claude](https://www.anthropic.com/claude)
+- [CodeRabbit](https://coderabbit.ai/)
+- [Codex](https://openai.com/codex/)
+- [KiloCode](https://kilocode.ai/)
+- [WARP](https://www.warp.dev)
+
+All code was written and/or reviewed and validated by the author.
+
+For full tool citation metadata, see the
+[AI-Assisted Development Tools](REFERENCES.md#ai-assisted-development-tools)
+section of [`REFERENCES.md`](REFERENCES.md).

--- a/README.md
+++ b/README.md
@@ -49,6 +49,16 @@ See [CHANGELOG.md](CHANGELOG.md) for release history and
 - Large matrices/dimensions with parallelism: use [`faer`](https://crates.io/crates/faer) if you need this
 - Alternate floating-point scalar families: `la-stack` supports `f64` and optional exact arithmetic, not `f32` / `f16` APIs
 
+## ✅ Use this crate when
+
+- Your matrices and vectors have small, fixed dimensions known at compile time
+- Stack allocation and `Copy` value semantics fit your data flow
+- You want explicit LU / LDLT / determinant APIs rather than a broad algebra toolkit
+- You need exact determinants, exact determinant signs, or exact linear solves
+  for fixed-size systems
+- Robust predicates matter for geometry-style workloads near degeneracy
+- You prefer a default build with no runtime dependencies
+
 ## 🔢 Scalar types
 
 The scalar model is intentionally limited to `f64` for floating-point work and
@@ -70,6 +80,12 @@ Add this to your `Cargo.toml`:
 [dependencies]
 la-stack = "0.4.2"
 ```
+
+### Feature flags
+
+- `default`: no runtime dependencies
+- `exact`: `BigRational` exact determinant and solve APIs
+- `bench`: Criterion, nalgebra, and faer for internal benchmarks
 
 Solve a 5×5 system via LU:
 
@@ -335,7 +351,14 @@ not store NaN or infinity.
 
 Raw data: [docs/assets/bench/vs_linalg_lu_solve_median.csv](docs/assets/bench/vs_linalg_lu_solve_median.csv)
 
-Summary (median time; lower is better). The “la-stack vs nalgebra/faer” columns show the % time reduction relative to each baseline (positive = la-stack faster):
+Representative benchmark: `lu_solve` factors the matrix and solves one
+right-hand side. Median time is lower-is-better, and the “la-stack vs
+nalgebra/faer” columns show the % time reduction relative to each baseline
+(positive = la-stack faster). This is not an aggregate score across all
+operations.
+
+For the full per-kernel comparison methodology, input construction, and
+release-comparison workflow details, see [docs/BENCHMARKING.md](docs/BENCHMARKING.md).
 
 <!-- BENCH_TABLE:lu_solve:median:new:BEGIN -->
 
@@ -397,12 +420,12 @@ CI runs `just ci` on Ubuntu, macOS, and Windows to keep platform coverage
 aligned with the local comprehensive validation path.
 
 For coverage commands and report locations, see [`docs/COVERAGE.md`](docs/COVERAGE.md).
-For the full set of developer commands, see `just --list` and `AGENTS.md`.
+For the full contributor workflow, see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## 📝 Citation
 
 If you use this library in academic work, please cite it using [CITATION.cff](CITATION.cff) (or GitHub's
-"Cite this repository" feature). A Zenodo DOI will be added for tagged releases.
+"Cite this repository" feature). Tagged releases are archived on Zenodo.
 
 ## 📚 References
 
@@ -410,24 +433,9 @@ For canonical references to the algorithms used by this crate, see [REFERENCES.m
 
 ## 🤖 AI Agents
 
-This repository contains an `AGENTS.md` file, which defines the canonical rules and invariants
-for all AI coding assistants and autonomous agents working on this codebase.
-
-AI tools (including `ChatGPT`, `Claude`, `CodeRabbit`, `KiloCode`, and `WARP`) are expected to read
-and follow `AGENTS.md` when proposing or applying changes.
-
-Portions of this library were developed with the assistance of these AI tools:
-
-- [ChatGPT](https://openai.com/chatgpt)
-- [Claude](https://www.anthropic.com/claude)
-- [CodeRabbit](https://coderabbit.ai/)
-- [KiloCode](https://kilocode.ai/)
-- [WARP](https://www.warp.dev)
-
-> All code was written and/or reviewed and validated by the author.
-
-For full tool citation metadata, see the [AI-Assisted Development Tools](REFERENCES.md#ai-assisted-development-tools)
-section of `REFERENCES.md`.
+AI coding assistants should read [AGENTS.md](AGENTS.md) before proposing or
+applying changes. See [CONTRIBUTING.md](CONTRIBUTING.md) for the repository's
+AI-assisted development note.
 
 ## 📄 License
 

--- a/benches/common/vs_linalg.rs
+++ b/benches/common/vs_linalg.rs
@@ -1,0 +1,122 @@
+//! Shared helpers for the `vs_linalg` benchmark and its smoke tests.
+
+use faer::linalg::solvers::{Ldlt as FaerLdlt, PartialPivLu};
+use faer::perm::PermRef;
+use nalgebra::SMatrix;
+
+/// Return `det(P)` for faer's permutation representation.
+///
+/// Sign(det(P)) is +1 for even permutations and -1 for odd. Parity is computed
+/// from the number of cycles: `sign = (-1)^(n - cycles)`.
+pub fn faer_perm_sign(p: PermRef<'_, usize>) -> f64 {
+    let (forward, _inverse) = p.arrays();
+    let n = forward.len();
+
+    let mut seen = vec![false; n];
+    let mut cycles = 0usize;
+
+    for start in 0..n {
+        if seen[start] {
+            continue;
+        }
+        cycles += 1;
+
+        let mut i = start;
+        while !seen[i] {
+            seen[i] = true;
+            i = forward[i];
+        }
+    }
+
+    if (n - cycles).is_multiple_of(2) {
+        1.0
+    } else {
+        -1.0
+    }
+}
+
+/// Compute a determinant from a faer partial-pivot LU factorization.
+pub fn faer_det_from_partial_piv_lu(lu: &PartialPivLu<f64>) -> f64 {
+    // For PA = LU with unit-lower L, det(A) = det(P) * det(U).
+    let u = lu.U();
+    let mut det = 1.0;
+    for i in 0..u.nrows() {
+        det *= u[(i, i)];
+    }
+    det * faer_perm_sign(lu.P())
+}
+
+/// Compute a determinant from a faer LDLT factorization.
+pub fn faer_det_from_ldlt(ldlt: &FaerLdlt<f64>) -> f64 {
+    let d = ldlt.D().column_vector();
+    let mut det = 1.0;
+    for i in 0..d.nrows() {
+        det *= d[i];
+    }
+    det
+}
+
+/// Return a deterministic, strictly diagonally-dominant benchmark matrix entry.
+#[inline]
+#[allow(clippy::cast_precision_loss)] // D, r, c are small integers, precision loss is not an issue.
+pub fn matrix_entry<const D: usize>(r: usize, c: usize) -> f64 {
+    if r == c {
+        // Strict diagonal dominance for stability.
+        (r as f64).mul_add(1.0e-3, (D as f64) + 1.0)
+    } else {
+        // Small, varying off-diagonals.
+        0.1 / ((r + c + 1) as f64)
+    }
+}
+
+/// Build the shared matrix rows used by all crates for a dimension.
+#[inline]
+pub fn make_matrix_rows<const D: usize>() -> [[f64; D]; D] {
+    let mut rows = [[0.0; D]; D];
+
+    for (r, row) in rows.iter_mut().enumerate() {
+        for (c, entry) in row.iter_mut().enumerate() {
+            *entry = matrix_entry::<D>(r, c);
+        }
+    }
+
+    rows
+}
+
+/// Return a deterministic benchmark vector entry.
+#[inline]
+#[allow(clippy::cast_precision_loss)] // i is a small integer, precision loss is not an issue.
+pub fn vector_entry(i: usize, offset: f64) -> f64 {
+    (i as f64) + 1.0 + offset
+}
+
+/// Build the shared vector input used by all crates for a dimension.
+#[inline]
+pub fn make_vector_array<const D: usize>(offset: f64) -> [f64; D] {
+    let mut data = [0.0; D];
+
+    for (i, entry) in data.iter_mut().enumerate() {
+        *entry = vector_entry(i, offset);
+    }
+
+    data
+}
+
+/// Compute nalgebra's matrix infinity norm using la-stack's row-sum convention.
+#[inline]
+pub fn nalgebra_inf_norm<const D: usize>(m: &SMatrix<f64, D, D>) -> f64 {
+    // Infinity norm = max absolute row sum.
+    let mut max_row_sum = 0.0;
+
+    for r in 0..D {
+        let mut row_sum = 0.0;
+        for c in 0..D {
+            row_sum += m[(r, c)].abs();
+        }
+        if row_sum > max_row_sum {
+            max_row_sum = row_sum;
+        }
+    }
+
+    max_row_sum
+}

--- a/benches/vs_linalg.rs
+++ b/benches/vs_linalg.rs
@@ -11,11 +11,21 @@ use std::fmt::Display;
 use std::hint::black_box;
 
 use criterion::Criterion;
-use faer::linalg::solvers::{PartialPivLu, Solve};
-use faer::perm::PermRef;
+use faer::linalg::solvers::Solve;
+use faer::{Mat, Side};
+use nalgebra::{SMatrix, SVector};
 use pastey::paste;
 
-use la_stack::{DEFAULT_PIVOT_TOL, Matrix, Vector};
+use la_stack::{DEFAULT_PIVOT_TOL, DEFAULT_SINGULAR_TOL, Matrix, Vector};
+
+mod common {
+    pub mod vs_linalg;
+}
+
+use common::vs_linalg::{
+    faer_det_from_ldlt, faer_det_from_partial_piv_lu, make_matrix_rows, make_vector_array,
+    matrix_entry, nalgebra_inf_norm, vector_entry,
+};
 
 /// Return a successful benchmark operation result or panic with the named operation.
 fn require_ok<T, E: Display>(result: Result<T, E>, operation: &str) -> T {
@@ -30,126 +40,11 @@ fn require_some<T>(value: Option<T>, operation: &str) -> T {
     value.unwrap_or_else(|| panic!("{operation} returned no result"))
 }
 
-/// Return `det(P)` for faer's permutation representation.
-///
-/// Sign(det(P)) is +1 for even permutations and -1 for odd. Parity is computed
-/// from the number of cycles: `sign = (-1)^(n - cycles)`.
-fn faer_perm_sign(p: PermRef<'_, usize>) -> f64 {
-    let (forward, _inverse) = p.arrays();
-    let n = forward.len();
-
-    let mut seen = vec![false; n];
-    let mut cycles = 0usize;
-
-    for start in 0..n {
-        if seen[start] {
-            continue;
-        }
-        cycles += 1;
-
-        let mut i = start;
-        while !seen[i] {
-            seen[i] = true;
-            i = forward[i];
-        }
-    }
-
-    if (n - cycles).is_multiple_of(2) {
-        1.0
-    } else {
-        -1.0
-    }
-}
-
-/// Compute a determinant from a faer partial-pivot LU factorization.
-fn faer_det_from_partial_piv_lu(lu: &PartialPivLu<f64>) -> f64 {
-    // For PA = LU with unit-lower L, det(A) = det(P) * det(U).
-    let u = lu.U();
-    let mut det = 1.0;
-    for i in 0..u.nrows() {
-        det *= u[(i, i)];
-    }
-    det * faer_perm_sign(lu.P())
-}
-
-/// Return a deterministic, strictly diagonally-dominant benchmark matrix entry.
-#[inline]
-#[allow(clippy::cast_precision_loss)] // D, r, c are small integers, precision loss is not an issue.
-fn matrix_entry<const D: usize>(r: usize, c: usize) -> f64 {
-    if r == c {
-        // Strict diagonal dominance for stability.
-        (r as f64).mul_add(1.0e-3, (D as f64) + 1.0)
-    } else {
-        // Small, varying off-diagonals.
-        0.1 / ((r + c + 1) as f64)
-    }
-}
-
-/// Build the shared matrix rows used by all crates for a dimension.
-#[inline]
-fn make_matrix_rows<const D: usize>() -> [[f64; D]; D] {
-    let mut rows = [[0.0; D]; D];
-
-    let mut r = 0;
-    while r < D {
-        let mut c = 0;
-        while c < D {
-            rows[r][c] = matrix_entry::<D>(r, c);
-            c += 1;
-        }
-        r += 1;
-    }
-
-    rows
-}
-
-/// Return a deterministic benchmark vector entry.
-#[inline]
-#[allow(clippy::cast_precision_loss)] // i is a small integer, precision loss is not an issue.
-fn vector_entry(i: usize, offset: f64) -> f64 {
-    (i as f64) + 1.0 + offset
-}
-
-/// Build the shared vector input used by all crates for a dimension.
-#[inline]
-fn make_vector_array<const D: usize>(offset: f64) -> [f64; D] {
-    let mut data = [0.0; D];
-
-    let mut i = 0;
-    while i < D {
-        data[i] = vector_entry(i, offset);
-        i += 1;
-    }
-
-    data
-}
-
-/// Compute nalgebra's matrix infinity norm using la-stack's row-sum convention.
-#[inline]
-fn nalgebra_inf_norm<const D: usize>(m: &nalgebra::SMatrix<f64, D, D>) -> f64 {
-    // Infinity norm = max absolute row sum.
-    let mut max_row_sum = 0.0;
-
-    let mut r = 0;
-    while r < D {
-        let mut row_sum = 0.0;
-        let mut c = 0;
-        while c < D {
-            row_sum += m[(r, c)].abs();
-            c += 1;
-        }
-        if row_sum > max_row_sum {
-            max_row_sum = row_sum;
-        }
-        r += 1;
-    }
-
-    max_row_sum
-}
-
-macro_rules! gen_vs_linalg_benches_for_dim {
-    ($c:expr, $d:literal) => {
-        paste! {{
+macro_rules! define_vs_linalg_benches_for_dim {
+    ($fn_name:ident, $d:literal) => {
+        paste! {
+            #[allow(clippy::too_many_lines)]
+            fn $fn_name(c: &mut Criterion) {
             // Isolate each dimension's inputs to keep types and captures clean.
             {
                 let a = require_ok(
@@ -169,22 +64,25 @@ macro_rules! gen_vs_linalg_benches_for_dim {
                     "la_stack vector construction",
                 );
 
-                let na = nalgebra::SMatrix::<f64, $d, $d>::from_fn(|r, c| matrix_entry::<$d>(r, c));
-                let nrhs = nalgebra::SVector::<f64, $d>::from_fn(|i, _| vector_entry(i, 0.0));
-                let nv1 = nalgebra::SVector::<f64, $d>::from_fn(|i, _| vector_entry(i, 0.0));
-                let nv2 = nalgebra::SVector::<f64, $d>::from_fn(|i, _| vector_entry(i, 1.0));
+                let na = SMatrix::<f64, $d, $d>::from_fn(|r, c| matrix_entry::<$d>(r, c));
+                let nrhs = SVector::<f64, $d>::from_fn(|i, _| vector_entry(i, 0.0));
+                let nv1 = SVector::<f64, $d>::from_fn(|i, _| vector_entry(i, 0.0));
+                let nv2 = SVector::<f64, $d>::from_fn(|i, _| vector_entry(i, 1.0));
 
-                let fa = faer::Mat::<f64>::from_fn($d, $d, |r, c| matrix_entry::<$d>(r, c));
-                let frhs = faer::Mat::<f64>::from_fn($d, 1, |i, _| vector_entry(i, 0.0));
-                let fv1 = faer::Mat::<f64>::from_fn($d, 1, |i, _| vector_entry(i, 0.0));
-                let fv2 = faer::Mat::<f64>::from_fn($d, 1, |i, _| vector_entry(i, 1.0));
+                let fa = Mat::<f64>::from_fn($d, $d, |r, c| matrix_entry::<$d>(r, c));
+                let frhs = Mat::<f64>::from_fn($d, 1, |i, _| vector_entry(i, 0.0));
+                let fv1 = Mat::<f64>::from_fn($d, 1, |i, _| vector_entry(i, 0.0));
+                let fv2 = Mat::<f64>::from_fn($d, 1, |i, _| vector_entry(i, 1.0));
 
                 // Precompute LU once for solve-only / det-only benchmarks.
                 let a_lu = require_ok(a.lu(DEFAULT_PIVOT_TOL), "precomputed la_stack LU");
+                let a_ldlt = require_ok(a.ldlt(DEFAULT_SINGULAR_TOL), "precomputed la_stack LDLT");
                 let na_lu = na.clone().lu();
+                let na_cholesky = require_some(na.clone().cholesky(), "precomputed nalgebra Cholesky");
                 let fa_lu = fa.partial_piv_lu();
+                let fa_ldlt = require_ok(fa.ldlt(Side::Lower), "precomputed faer LDLT");
 
-                let mut [<group_d $d>] = ($c).benchmark_group(concat!("d", stringify!($d)));
+                let mut [<group_d $d>] = c.benchmark_group(concat!("d", stringify!($d)));
 
                 // === Determinant via LU (factor + det) ===
                 [<group_d $d>].bench_function("la_stack_det_via_lu", |bencher| {
@@ -247,6 +145,37 @@ macro_rules! gen_vs_linalg_benches_for_dim {
                     });
                 });
 
+                // === SPD factorization (LDLT / Cholesky) ===
+                [<group_d $d>].bench_function("la_stack_ldlt", |bencher| {
+                    bencher.iter(|| {
+                        let ldlt = require_ok(
+                            black_box(a).ldlt(DEFAULT_SINGULAR_TOL),
+                            "la_stack LDLT factorization",
+                        );
+                        let _ = black_box(ldlt);
+                    });
+                });
+
+                [<group_d $d>].bench_function("nalgebra_cholesky", |bencher| {
+                    bencher.iter(|| {
+                        let chol = require_some(
+                            black_box(na.clone()).cholesky(),
+                            "nalgebra Cholesky factorization",
+                        );
+                        black_box(chol);
+                    });
+                });
+
+                [<group_d $d>].bench_function("faer_ldlt", |bencher| {
+                    bencher.iter(|| {
+                        let ldlt = require_ok(
+                            black_box(&fa).ldlt(Side::Lower),
+                            "faer LDLT factorization",
+                        );
+                        black_box(ldlt);
+                    });
+                });
+
                 // === LU solve (factor + solve) ===
                 [<group_d $d>].bench_function("la_stack_lu_solve", |bencher| {
                     bencher.iter(|| {
@@ -274,6 +203,43 @@ macro_rules! gen_vs_linalg_benches_for_dim {
                     bencher.iter(|| {
                         let lu = black_box(&fa).partial_piv_lu();
                         let x = lu.solve(black_box(&frhs));
+                        black_box(x);
+                    });
+                });
+
+                // === SPD solve (factor + solve) ===
+                [<group_d $d>].bench_function("la_stack_ldlt_solve", |bencher| {
+                    bencher.iter(|| {
+                        let ldlt = require_ok(
+                            black_box(a).ldlt(DEFAULT_SINGULAR_TOL),
+                            "la_stack LDLT factorization",
+                        );
+                        let x = require_ok(
+                            ldlt.solve_vec(black_box(rhs)),
+                            "la_stack LDLT solve",
+                        );
+                        let _ = black_box(x);
+                    });
+                });
+
+                [<group_d $d>].bench_function("nalgebra_cholesky_solve", |bencher| {
+                    bencher.iter(|| {
+                        let chol = require_some(
+                            black_box(na.clone()).cholesky(),
+                            "nalgebra Cholesky factorization",
+                        );
+                        let x = chol.solve(black_box(&nrhs));
+                        black_box(x);
+                    });
+                });
+
+                [<group_d $d>].bench_function("faer_ldlt_solve", |bencher| {
+                    bencher.iter(|| {
+                        let ldlt = require_ok(
+                            black_box(&fa).ldlt(Side::Lower),
+                            "faer LDLT factorization",
+                        );
+                        let x = ldlt.solve(black_box(&frhs));
                         black_box(x);
                     });
                 });
@@ -306,6 +272,31 @@ macro_rules! gen_vs_linalg_benches_for_dim {
                     });
                 });
 
+                // === Solve using a precomputed SPD factorization ===
+                [<group_d $d>].bench_function("la_stack_solve_from_ldlt", |bencher| {
+                    bencher.iter(|| {
+                        let x = require_ok(
+                            a_ldlt.solve_vec(black_box(rhs)),
+                            "precomputed la_stack LDLT solve",
+                        );
+                        let _ = black_box(x);
+                    });
+                });
+
+                [<group_d $d>].bench_function("nalgebra_solve_from_cholesky", |bencher| {
+                    bencher.iter(|| {
+                        let x = na_cholesky.solve(black_box(&nrhs));
+                        black_box(x);
+                    });
+                });
+
+                [<group_d $d>].bench_function("faer_solve_from_ldlt", |bencher| {
+                    bencher.iter(|| {
+                        let x = fa_ldlt.solve(black_box(&frhs));
+                        black_box(x);
+                    });
+                });
+
                 // === Determinant from a precomputed LU ===
                 [<group_d $d>].bench_function("la_stack_det_from_lu", |bencher| {
                     bencher.iter(|| {
@@ -324,6 +315,28 @@ macro_rules! gen_vs_linalg_benches_for_dim {
                 [<group_d $d>].bench_function("faer_det_from_lu", |bencher| {
                     bencher.iter(|| {
                         let det = faer_det_from_partial_piv_lu(&fa_lu);
+                        black_box(det);
+                    });
+                });
+
+                // === Determinant from a precomputed SPD factorization ===
+                [<group_d $d>].bench_function("la_stack_det_from_ldlt", |bencher| {
+                    bencher.iter(|| {
+                        let det = require_ok(a_ldlt.det(), "precomputed la_stack LDLT determinant");
+                        black_box(det);
+                    });
+                });
+
+                [<group_d $d>].bench_function("nalgebra_det_from_cholesky", |bencher| {
+                    bencher.iter(|| {
+                        let det = na_cholesky.determinant();
+                        black_box(det);
+                    });
+                });
+
+                [<group_d $d>].bench_function("faer_det_from_ldlt", |bencher| {
+                    bencher.iter(|| {
+                        let det = faer_det_from_ldlt(&fa_ldlt);
                         black_box(det);
                     });
                 });
@@ -418,22 +431,32 @@ macro_rules! gen_vs_linalg_benches_for_dim {
 
                 [<group_d $d>].finish();
             }
-        }}
+        }
+    }
     };
 }
+
+define_vs_linalg_benches_for_dim!(bench_d2, 2);
+define_vs_linalg_benches_for_dim!(bench_d3, 3);
+define_vs_linalg_benches_for_dim!(bench_d4, 4);
+define_vs_linalg_benches_for_dim!(bench_d5, 5);
+define_vs_linalg_benches_for_dim!(bench_d8, 8);
+define_vs_linalg_benches_for_dim!(bench_d16, 16);
+define_vs_linalg_benches_for_dim!(bench_d32, 32);
+define_vs_linalg_benches_for_dim!(bench_d64, 64);
 
 fn main() {
     let mut c = Criterion::default().configure_from_args();
 
-    gen_vs_linalg_benches_for_dim!(&mut c, 2);
-    gen_vs_linalg_benches_for_dim!(&mut c, 3);
-    gen_vs_linalg_benches_for_dim!(&mut c, 4);
-    gen_vs_linalg_benches_for_dim!(&mut c, 5);
+    bench_d2(&mut c);
+    bench_d3(&mut c);
+    bench_d4(&mut c);
+    bench_d5(&mut c);
 
-    gen_vs_linalg_benches_for_dim!(&mut c, 8);
-    gen_vs_linalg_benches_for_dim!(&mut c, 16);
-    gen_vs_linalg_benches_for_dim!(&mut c, 32);
-    gen_vs_linalg_benches_for_dim!(&mut c, 64);
+    bench_d8(&mut c);
+    bench_d16(&mut c);
+    bench_d32(&mut c);
+    bench_d64(&mut c);
 
     c.final_summary();
 }

--- a/docs/BENCHMARKING.md
+++ b/docs/BENCHMARKING.md
@@ -9,6 +9,10 @@ la-stack has two Criterion benchmark suites:
 - **`vs_linalg`** (`benches/vs_linalg.rs`) — compares la-stack against
   nalgebra and faer across D=2–64 for LU, solve, det, dot, norm, etc.
   Use this to answer "why choose la-stack over other crates?"
+  The suite also includes SPD factorization rows for la-stack LDLT, faer
+  LDLT, and nalgebra Cholesky. The nalgebra rows are labelled Cholesky
+  because nalgebra does not expose a dense LDLT factorization in the
+  dependency version used here.
 
 - **`exact`** (`benches/exact.rs`) — measures exact-arithmetic methods
   (`det_exact`, `solve_exact`, `det_sign_exact`, etc.) alongside f64
@@ -36,23 +40,77 @@ la-stack has two Criterion benchmark suites:
   `solve_exact_f64`) so the resulting tables are directly comparable
   across input classes.
 
+## `vs_linalg` methodology
+
+`vs_linalg` is a per-kernel comparison, not a single aggregate score. Each
+reported row compares one operation for one dimension `D`, using Criterion's
+selected statistic from `target/criterion/d{D}/{benchmark}/{sample}/estimates.json`.
+The default report and README table use Criterion's `median.point_estimate`
+in nanoseconds. Lower is better.
+
+All three crates receive equivalent deterministic inputs for a given
+dimension:
+
+- matrix entries come from the same strictly diagonally-dominant generator
+  (`matrix_entry::<D>`)
+- right-hand sides and vector inputs come from the same deterministic vector
+  generator
+- each benchmark uses `black_box` around inputs and outputs to keep the
+  measured operation visible to the optimizer
+
+The integration smoke test `tests/vs_linalg_inputs.rs` reuses the benchmark
+input helpers and verifies that la-stack, nalgebra, and faer agree on the
+determinant, solve, dot, and infinity-norm results for D=2..=5. Run it with
+`cargo test --features bench --test vs_linalg_inputs` when changing benchmark
+input construction, adding comparable kernels, or updating the `faer` or
+`nalgebra` benchmark dependencies.
+
+The main comparable metrics are:
+
+- `det_via_lu` — factor the matrix and compute determinant from the LU factor
+- `lu` — factorization only
+- `lu_solve` — factor the matrix and solve one right-hand side
+- `solve_from_lu` — solve one right-hand side using a precomputed LU factor
+- `det_from_lu` — compute determinant using a precomputed LU factor
+- `dot` — vector dot product
+- `norm2_sq` — squared Euclidean vector norm
+- `inf_norm` — matrix infinity norm, implemented as maximum absolute row sum
+
+Additional SPD metrics compare la-stack LDLT against faer LDLT and nalgebra
+Cholesky. These rows are labelled by algorithm (`ldlt` or `cholesky`) because
+nalgebra does not expose a dense LDLT factorization in the dependency version
+used here. They should be read as SPD factorization/solve/determinant
+comparisons, not as identical algorithm comparisons across all three crates.
+
+Release-signal reports compare latest la-stack measurements against a saved
+la-stack baseline, and show saved nalgebra/faer baseline timings as context
+where a matching peer benchmark exists. That keeps iteration cheap while still
+making the release signal auditable. The full `vs_linalg` run remains the
+source of README plots and crate-to-crate comparison tables.
+
 ## Quick reference
 
 ```bash
 # Run vs_linalg benchmarks
 just bench-vs-linalg
 
+# Run only la-stack rows from vs_linalg
+just bench-vs-linalg-la-stack
+
 # Run exact-arithmetic benchmarks
 just bench-exact
 
-# Save an exact baseline (e.g., before optimising)
-just bench-save-baseline <baseline>
+# Run the cheaper latest measurements used for latest-vs-last reports
+just bench-latest
 
-# Compare current code against a saved baseline
-just bench-compare <baseline>
+# Save a full baseline named "last"
+just bench-save-last
 
-# Generate a snapshot without comparison
+# Compare latest measurements against the saved "last" baseline
 just bench-compare
+
+# Run latest measurements and compare against "last"
+just bench-latest-vs-last
 ```
 
 ## Comparing performance across releases
@@ -60,18 +118,41 @@ just bench-compare
 Criterion baselines are saved into `target/criterion/` and persist across
 `git checkout` but **not** across `cargo clean`.
 
+### Latest vs last
+
+The default workflow is optimized for the common maintenance question:
+"how does latest la-stack compare to the last release?"
+
+At release time, save a full baseline:
+
+```bash
+just bench-save-last
+```
+
+During development, run the cheaper latest path:
+
+```bash
+just bench-latest-vs-last
+```
+
+`bench-latest` runs exact arithmetic plus only the la-stack rows from
+`vs_linalg`. The comparison report still shows the last-release nalgebra
+and faer timings for matching rows, so you can see whether a la-stack
+change improves or weakens the release signal without rerunning third-party
+benchmarks on every iteration.
+
 ### Workflow
 
 ```bash
-# 1. Check out the old release and save its baseline
+# 1. Check out the old release and save its full baseline
 git checkout v0.2.0
 just bench-save-baseline v0.2.0
 
-# 2. Switch to current code and run benchmarks
+# 2. Switch to current code and run latest la-stack measurements
 git checkout main   # or your feature branch
-just bench-exact    # populates target/criterion/*/new/
+just bench-latest   # populates target/criterion/*/new/
 
-# 3. Generate a comparison table in docs/PERFORMANCE.md
+# 3. Generate a local comparison report
 just bench-compare v0.2.0
 ```
 
@@ -79,9 +160,17 @@ You can save multiple baselines and compare against any of them.
 
 ### Output
 
-`just bench-compare` writes `docs/PERFORMANCE.md` (gitignored — it contains
-machine-specific timings). The file includes per-dimension tables showing
-median times, percent change, and speedup for each benchmark.
+`just bench-compare` writes `target/bench-reports/performance.md` by
+default. The file contains machine-specific timings and is intentionally
+local. The report includes per-dimension tables showing median times,
+percent change, speedup, and last-release nalgebra/faer context where a
+matching `vs_linalg` peer exists.
+
+To generate a current snapshot without a saved baseline:
+
+```bash
+uv run bench-compare --snapshot
+```
 
 ## vs\_linalg plotting
 
@@ -102,6 +191,7 @@ At release time, save a baseline so future work can compare against it:
 
 ```bash
 just bench-save-baseline $TAG
+just bench-save-last
 ```
 
 See `docs/RELEASING.md` step 5 for where this fits in the release process.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -100,14 +100,21 @@ just plot-vs-linalg-readme
 Review the updated table in `README.md` and the plot in `docs/assets/` for
 accuracy.
 
-5. Save an exact-arithmetic benchmark baseline for this release
+5. Save benchmark baselines for this release
 
 ```bash
-# Run exact benchmarks and save a named Criterion baseline
+# Save a named full baseline for this release
 just bench-save-baseline $TAG
+
+# Also refresh the conventional "last" baseline used by local
+# latest-vs-last performance checks
+just bench-save-last
 ```
 
-This baseline can be compared against in future optimization work.
+These baselines can be compared against in future optimization work. The
+default local report command, `just bench-compare`, compares latest
+measurements against `last` and writes `target/bench-reports/performance.md`;
+it does not update README benchmark tables or committed release artifacts.
 See `docs/BENCHMARKING.md` for the full comparison workflow.
 
 6. Validate the release branch

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -6,12 +6,12 @@ maturity, downstream need, and validation quality. Concrete implementation work
 is tracked as GitHub issues; keep this document focused on release direction,
 ordering, and non-goals.
 
-Pre-1.0 releases may still revise public APIs when that makes the crate more
-correct or easier to use safely. The `v0.4.x` line should stay on stable Rust
-and focus on documentation, downstream ergonomics, API-contract cleanup,
-validation, invariant audits, and benchmark coverage. The `v0.5.0` line is
-reserved for work that depends on stabilized `generic_const_exprs` or equivalent
-const-generic expressiveness.
+Until v1.0, API breaks are acceptable when they improve correctness,
+performance, or orthogonality. The `v0.4.x` line should stay on stable Rust and
+focus on documentation, downstream ergonomics, API-contract cleanup, validation,
+invariant audits, benchmark coverage, and release/tooling hardening. The
+`v0.5.0` line is reserved for work that depends on stabilized
+`generic_const_exprs` or equivalent const-generic expressiveness.
 
 ## Scalar Scope
 
@@ -31,9 +31,8 @@ coverage should use larger linear-algebra ecosystems such as `nalgebra` or
 
 ### v0.4.2 Stable Rust Cleanup
 
-The `v0.4.2` milestone collects the work that can be done on today's stable
-Rust while keeping the crate useful to downstream geometry crates. The GitHub
-native Blocking / Is blocked by graph mirrors this order:
+The `v0.4.2` milestone collected work that could be done on stable Rust while
+keeping the crate useful to downstream geometry crates:
 
 Completed foundation work:
 
@@ -55,7 +54,7 @@ Completed foundation work:
   [#117](https://github.com/acgetchell/la-stack/issues/117) cleaned up
   Markdown/YAML tooling, CI speed, and shared Rust workflow/security checks.
 
-Current API-invariant cleanup:
+API-invariant cleanup:
 
 - [#126](https://github.com/acgetchell/la-stack/issues/126) is resolved as an
   internal parse-don't-validate design rather than a public proof-bearing API.
@@ -79,7 +78,7 @@ Current API-invariant cleanup:
   `ERR_COEFF_4` are documented as dimension-specific roundoff multipliers over
   the absolute Leibniz sum, not caller-tuned tolerances.
 
-Remaining release blockers:
+Final release blockers:
 
 - [#125](https://github.com/acgetchell/la-stack/issues/125) - Add a Semgrep
   guardrail against `unwrap` / `expect` in examples, benches, and doctests.
@@ -90,6 +89,19 @@ The broad shape is now: document scalar scope, add downstream dispatch
 ergonomics, clean up small API contracts, tighten validation, encode reusable
 invariants behind the public raw-boundary API, lock examples and benchmarks into
 proper error handling, then finish with broader benchmark work.
+
+### v0.4.3 Benchmark and Tooling Hardening
+
+Before the const-generic API revision, tighten the benchmark and tooling story so
+performance claims are auditable across releases and Python support scripts have
+a modern typed baseline.
+
+- [#137](https://github.com/acgetchell/la-stack/issues/137) - Investigate
+  checked vector kernel performance for v0.4.3.
+- [#138](https://github.com/acgetchell/la-stack/issues/138) - Add first-class
+  cross-release performance comparison tooling.
+- [#142](https://github.com/acgetchell/la-stack/issues/142) - Update Python
+  tooling to 3.13 and parse scripts at boundaries.
 
 ### v0.5.0 Generic Const Expressions
 

--- a/justfile
+++ b/justfile
@@ -170,25 +170,50 @@ bench:
 bench-compile:
     RUSTFLAGS='-D warnings' cargo bench --no-run --features bench
 
-# Compare exact-arithmetic benchmarks against a saved baseline.
-# Omit the baseline arg to generate a snapshot without comparison.
-bench-compare baseline="": python-sync
+# Run the cheaper latest measurements used for latest-vs-last reports.
+bench-latest: bench-vs-linalg-la-stack bench-exact
+
+# Run latest measurements and render the latest-vs-last performance report.
+bench-latest-vs-last baseline="last": bench-latest python-sync
+    uv run bench-compare {{baseline}}
+
+# Compare latest measurements against a saved baseline.
+# Defaults to the `last` full-release baseline.
+bench-compare baseline="last" suite="all" scope="release-signal": python-sync
     #!/usr/bin/env bash
     set -euo pipefail
     baseline="{{baseline}}"
-    if [ -n "$baseline" ]; then
-        uv run bench-compare "$baseline"
-    else
-        uv run bench-compare
-    fi
+    uv run bench-compare "$baseline" --suite "{{suite}}" --scope "{{scope}}"
 
 # Run the exact-arithmetic benchmark suite.
 bench-exact:
     cargo bench --features bench,exact --bench exact
 
-# Save a Criterion baseline for the exact-arithmetic benchmarks.
-bench-save-baseline tag:
-    cargo bench --features bench,exact --bench exact -- --save-baseline {{tag}}
+# Save a full Criterion baseline for the previous release signal.
+bench-save-last:
+    just bench-save-baseline last
+
+# Save a Criterion baseline. Defaults to all release-signal benchmark suites.
+bench-save-baseline tag suite="all":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    suite="{{suite}}"
+    case "$suite" in
+        all)
+            cargo bench --features bench --bench vs_linalg -- --save-baseline {{tag}}
+            cargo bench --features bench,exact --bench exact -- --save-baseline {{tag}}
+            ;;
+        exact)
+            cargo bench --features bench,exact --bench exact -- --save-baseline {{tag}}
+            ;;
+        vs_linalg)
+            cargo bench --features bench --bench vs_linalg -- --save-baseline {{tag}}
+            ;;
+        *)
+            echo "unknown benchmark suite: $suite" >&2
+            exit 2
+            ;;
+    esac
 
 # Bench the la-stack vs nalgebra/faer comparison suite.
 bench-vs-linalg filter="":
@@ -200,6 +225,10 @@ bench-vs-linalg filter="":
     else
         cargo bench --features bench --bench vs_linalg
     fi
+
+# Bench only la-stack rows from the vs_linalg suite for cheap latest-vs-last comparisons.
+bench-vs-linalg-la-stack:
+    cargo bench --features bench --bench vs_linalg -- la_stack
 
 # Quick iteration (reduced runtime, no Criterion HTML).
 bench-vs-linalg-quick filter="":
@@ -358,7 +387,11 @@ help-workflows:
     @echo "Benchmarks:"
     @echo "  just bench                 # Run benchmarks"
     @echo "  just bench-compile          # Compile benches with warnings-as-errors"
+    @echo "  just bench-latest           # Run cheap latest measurements"
+    @echo "  just bench-latest-vs-last   # Run latest and compare against last"
+    @echo "  just bench-save-last        # Save full baseline as 'last'"
     @echo "  just bench-vs-linalg        # Run vs_linalg bench (optional filter)"
+    @echo "  just bench-vs-linalg-la-stack # Run la-stack rows from vs_linalg"
     @echo "  just bench-vs-linalg-quick  # Quick vs_linalg bench (reduced samples)"
     @echo ""
     @echo "Benchmark plotting:"

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -14,6 +14,25 @@ uv sync --group dev
 
 ## How to use it
 
+### Comparing latest performance against the last release
+
+The comparison script reads Criterion output and writes a local report to
+`target/bench-reports/performance.md` by default:
+
+```bash
+# Save a full release baseline named "last"
+just bench-save-last
+
+# Run exact benches plus la-stack rows from vs_linalg, then compare to last
+just bench-latest-vs-last
+
+# Re-render from existing Criterion output
+just bench-compare
+```
+
+Use `uv run bench-compare --snapshot` for a no-baseline snapshot, or
+`uv run bench-compare <baseline>` to compare against a named saved baseline.
+
 ### Plotting Criterion benchmarks (la-stack vs nalgebra/faer)
 
 The plotter reads Criterion output under:

--- a/scripts/bench_compare.py
+++ b/scripts/bench_compare.py
@@ -1,22 +1,22 @@
 #!/usr/bin/env python3
-"""Compare exact-arithmetic benchmark results across Criterion baselines.
+"""Compare la-stack benchmark results across Criterion baselines.
 
 Reads Criterion output under:
   target/criterion/{group}/{bench}/{sample}/estimates.json
 
-And writes a markdown performance table to docs/PERFORMANCE.md.
+And writes a local markdown performance report.
 
 Typical workflow (see docs/RELEASING.md):
 
-  # Save baseline at a release tag
-  just bench-save-baseline v0.3.0
+  # Save a full baseline for the last release
+  just bench-save-last
 
   # ... make optimisations ...
 
-  # Compare current performance against the saved baseline
-  just bench-compare v0.3.0
+  # Run the cheap latest-vs-last workflow
+  just bench-latest-vs-last
 
-  # Or just generate a snapshot of current performance
+  # Or just render the report from existing Criterion output
   just bench-compare
 """
 
@@ -32,6 +32,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Protocol
 
+from criterion_dim_plot import METRICS
 from subprocess_utils import ExecutableNotFoundError, run_git_command
 
 # ---------------------------------------------------------------------------
@@ -62,11 +63,48 @@ EXACT_GROUPS: dict[str, list[str]] = {
     "exact_hilbert_5x5": _EXTREME_BENCHES,
 }
 
+VS_LINALG_LA_STACK_ONLY_BENCHES_BY_METRIC: dict[str, list[str]] = {
+    "det_via_lu": ["la_stack_det"],
+}
+VS_LINALG_EXTRA_PEER_BENCHES_BY_METRIC: dict[str, list[tuple[str, str, str]]] = {
+    "lu": [("la_stack_ldlt", "nalgebra_cholesky", "faer_ldlt")],
+    "lu_solve": [("la_stack_ldlt_solve", "nalgebra_cholesky_solve", "faer_ldlt_solve")],
+    "solve_from_lu": [("la_stack_solve_from_ldlt", "nalgebra_solve_from_cholesky", "faer_solve_from_ldlt")],
+    "det_from_lu": [("la_stack_det_from_ldlt", "nalgebra_det_from_cholesky", "faer_det_from_ldlt")],
+}
+VS_LINALG_BENCH_ORDER: list[str] = [
+    bench
+    for metric_key, metric in METRICS.items()
+    for bench in (
+        [
+            metric.la_bench,
+            *VS_LINALG_LA_STACK_ONLY_BENCHES_BY_METRIC.get(metric_key, []),
+            metric.na_bench,
+            metric.fa_bench,
+            *[peer_bench for peer_group in VS_LINALG_EXTRA_PEER_BENCHES_BY_METRIC.get(metric_key, []) for peer_bench in peer_group],
+        ]
+    )
+]
+
+VS_LINALG_LA_STACK_BENCHES: frozenset[str] = frozenset(bench for bench in VS_LINALG_BENCH_ORDER if bench.startswith("la_stack_"))
+VS_LINALG_BASELINE_PEERS: dict[str, tuple[str, str]] = {metric.la_bench: (metric.na_bench, metric.fa_bench) for metric in METRICS.values()}
+VS_LINALG_BASELINE_PEERS.update(
+    {
+        la_stack_bench: (nalgebra_bench, faer_bench)
+        for peer_groups in VS_LINALG_EXTRA_PEER_BENCHES_BY_METRIC.values()
+        for la_stack_bench, nalgebra_bench, faer_bench in peer_groups
+    }
+)
+
+SUITE_CHOICES: tuple[str, ...] = ("all", "exact", "vs_linalg")
+SCOPE_CHOICES: tuple[str, ...] = ("release-signal", "all-benches")
+
 
 @dataclass(frozen=True, slots=True)
 class BenchResult:
     """A single benchmark measurement (point estimate + confidence interval)."""
 
+    suite: str
     group: str
     bench: str
     point_ns: float
@@ -78,12 +116,25 @@ class BenchResult:
 class Comparison:
     """A comparison between baseline and current benchmark results."""
 
+    suite: str
     group: str
     bench: str
     baseline_ns: float
     current_ns: float
     speedup: float  # baseline / current (>1 = faster)
     pct_change: float  # signed percent change (negative = faster)
+    baseline_nalgebra_ns: float | None = None
+    baseline_faer_ns: float | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ReportSettings:
+    """Settings rendered into the benchmark report header."""
+
+    baseline_name: str | None
+    stat: str
+    suite: str
+    scope: str
 
 
 # ---------------------------------------------------------------------------
@@ -95,30 +146,73 @@ def _repo_root() -> Path:
     return Path(__file__).resolve().parents[1]
 
 
+def _dim_from_vs_linalg_group(name: str) -> int | None:
+    """Parse a vs_linalg Criterion group name such as d2 or d64."""
+    if not name.startswith("d"):
+        return None
+    suffix = name.removeprefix("d")
+    if not suffix.isdecimal():
+        return None
+    return int(suffix)
+
+
 def _read_estimate(estimates_json: Path, stat: str = "median") -> tuple[float, float, float]:
     """Read a point estimate and confidence interval from Criterion estimates.json.
 
     Returns (point_ns, ci_lo_ns, ci_hi_ns).
     """
-    data = json.loads(estimates_json.read_text(encoding="utf-8"))
+    try:
+        data = json.loads(estimates_json.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as err:
+        msg = f"malformed Criterion estimates JSON in {estimates_json}: {err}"
+        raise ValueError(msg) from err
+
+    if not isinstance(data, dict):
+        msg = f"expected JSON object in {estimates_json}"
+        raise TypeError(msg)
 
     stat_obj = data.get(stat)
     if not isinstance(stat_obj, dict):
         msg = f"stat '{stat}' not found in {estimates_json}"
         raise KeyError(msg)
 
-    point = float(stat_obj["point_estimate"])
+    point = _read_numeric_field(stat_obj, "point_estimate", estimates_json, stat)
     ci = stat_obj.get("confidence_interval")
     if not isinstance(ci, dict):
         return (point, point, point)
 
-    lo = float(ci.get("lower_bound", point))
-    hi = float(ci.get("upper_bound", point))
+    lo = _read_numeric_field(ci, "lower_bound", estimates_json, stat, default=point)
+    hi = _read_numeric_field(ci, "upper_bound", estimates_json, stat, default=point)
     return (point, lo, hi)
 
 
-def _collect_results(criterion_dir: Path, sample: str, stat: str) -> list[BenchResult]:
-    """Collect all benchmark results from Criterion output."""
+def _read_numeric_field(
+    obj: dict[str, object],
+    field: str,
+    estimates_json: Path,
+    stat: str,
+    *,
+    default: float | None = None,
+) -> float:
+    """Read a numeric Criterion field with file and statistic context."""
+    if field not in obj:
+        if default is not None:
+            return default
+        msg = f"field '{field}' for stat '{stat}' not found in {estimates_json}"
+        raise KeyError(msg)
+    value = obj[field]
+    if isinstance(value, bool) or not isinstance(value, int | float | str):
+        msg = f"field '{field}' for stat '{stat}' in {estimates_json} is not numeric: {value!r}"
+        raise TypeError(msg)
+    try:
+        return float(value)
+    except ValueError as err:
+        msg = f"field '{field}' for stat '{stat}' in {estimates_json} is not numeric: {value!r}"
+        raise ValueError(msg) from err
+
+
+def _collect_exact_results(criterion_dir: Path, sample: str, stat: str) -> list[BenchResult]:
+    """Collect exact-arithmetic benchmark results from Criterion output."""
     results: list[BenchResult] = []
 
     for group, benches in EXACT_GROUPS.items():
@@ -132,17 +226,57 @@ def _collect_results(criterion_dir: Path, sample: str, stat: str) -> list[BenchR
                 continue
 
             point, lo, hi = _read_estimate(est_path, stat)
-            results.append(BenchResult(group=group, bench=bench, point_ns=point, ci_lo_ns=lo, ci_hi_ns=hi))
+            results.append(BenchResult(suite="exact", group=group, bench=bench, point_ns=point, ci_lo_ns=lo, ci_hi_ns=hi))
 
     return results
 
 
-def _collect_comparisons(
+def _ordered_vs_linalg_benches(group_dir: Path, sample: str) -> list[str]:
+    """Return present vs_linalg benches in a stable, metric-aware order."""
+    present = {child.name for child in group_dir.iterdir() if child.is_dir() and (child / sample / "estimates.json").exists()}
+    ordered = [bench for bench in VS_LINALG_BENCH_ORDER if bench in present]
+    extras = sorted(present.difference(VS_LINALG_BENCH_ORDER))
+    return [*ordered, *extras]
+
+
+def _collect_vs_linalg_results(criterion_dir: Path, sample: str, stat: str) -> list[BenchResult]:
+    """Collect vs_linalg benchmark results from Criterion output."""
+    results: list[BenchResult] = []
+    dim_groups: list[tuple[int, Path]] = []
+
+    for group_dir in criterion_dir.iterdir():
+        if not group_dir.is_dir():
+            continue
+        dim = _dim_from_vs_linalg_group(group_dir.name)
+        if dim is None:
+            continue
+        dim_groups.append((dim, group_dir))
+
+    for _dim, group_dir in sorted(dim_groups, key=lambda item: item[0]):
+        for bench in _ordered_vs_linalg_benches(group_dir, sample):
+            est_path = group_dir / bench / sample / "estimates.json"
+            point, lo, hi = _read_estimate(est_path, stat)
+            results.append(BenchResult(suite="vs_linalg", group=group_dir.name, bench=bench, point_ns=point, ci_lo_ns=lo, ci_hi_ns=hi))
+
+    return results
+
+
+def _collect_results(criterion_dir: Path, sample: str, stat: str, suite: str = "all") -> list[BenchResult]:
+    """Collect benchmark results from Criterion output."""
+    results: list[BenchResult] = []
+    if suite in ("all", "exact"):
+        results.extend(_collect_exact_results(criterion_dir, sample, stat))
+    if suite in ("all", "vs_linalg"):
+        results.extend(_collect_vs_linalg_results(criterion_dir, sample, stat))
+    return results
+
+
+def _collect_exact_comparisons(
     criterion_dir: Path,
     baseline_name: str,
     stat: str,
 ) -> list[Comparison]:
-    """Compare current (new) results against a named baseline."""
+    """Compare current exact-arithmetic results against a named baseline."""
     comparisons: list[Comparison] = []
 
     for group, benches in EXACT_GROUPS.items():
@@ -165,6 +299,7 @@ def _collect_comparisons(
 
             comparisons.append(
                 Comparison(
+                    suite="exact",
                     group=group,
                     bench=bench,
                     baseline_ns=base_point,
@@ -174,6 +309,103 @@ def _collect_comparisons(
                 )
             )
 
+    return comparisons
+
+
+def _ordered_vs_linalg_comparison_benches(group_dir: Path, baseline_name: str, scope: str) -> list[str]:
+    """Return present vs_linalg benches that have both current and baseline data."""
+    present = {
+        child.name
+        for child in group_dir.iterdir()
+        if child.is_dir() and (child / "new" / "estimates.json").exists() and (child / baseline_name / "estimates.json").exists()
+    }
+    if scope == "release-signal":
+        present = present.intersection(VS_LINALG_LA_STACK_BENCHES)
+    ordered = [bench for bench in VS_LINALG_BENCH_ORDER if bench in present]
+    extras = sorted(present.difference(VS_LINALG_BENCH_ORDER))
+    return [*ordered, *extras]
+
+
+def _read_optional_point(estimates_json: Path, stat: str) -> float | None:
+    """Read an optional Criterion point estimate."""
+    if not estimates_json.exists():
+        return None
+    point, _, _ = _read_estimate(estimates_json, stat)
+    return point
+
+
+def _baseline_peer_times(group_dir: Path, bench: str, baseline_name: str, stat: str) -> tuple[float | None, float | None]:
+    """Return last-release nalgebra/faer context for a la-stack vs_linalg bench."""
+    peers = VS_LINALG_BASELINE_PEERS.get(bench)
+    if peers is None:
+        return (None, None)
+
+    nalgebra_bench, faer_bench = peers
+    nalgebra_ns = _read_optional_point(group_dir / nalgebra_bench / baseline_name / "estimates.json", stat)
+    faer_ns = _read_optional_point(group_dir / faer_bench / baseline_name / "estimates.json", stat)
+    return (nalgebra_ns, faer_ns)
+
+
+def _collect_vs_linalg_comparisons(
+    criterion_dir: Path,
+    baseline_name: str,
+    stat: str,
+    scope: str,
+) -> list[Comparison]:
+    """Compare current vs_linalg results against a named baseline."""
+    comparisons: list[Comparison] = []
+    dim_groups: list[tuple[int, Path]] = []
+
+    for group_dir in criterion_dir.iterdir():
+        if not group_dir.is_dir():
+            continue
+        dim = _dim_from_vs_linalg_group(group_dir.name)
+        if dim is None:
+            continue
+        dim_groups.append((dim, group_dir))
+
+    for _dim, group_dir in sorted(dim_groups, key=lambda item: item[0]):
+        for bench in _ordered_vs_linalg_comparison_benches(group_dir, baseline_name, scope):
+            new_path = group_dir / bench / "new" / "estimates.json"
+            base_path = group_dir / bench / baseline_name / "estimates.json"
+
+            new_point, _, _ = _read_estimate(new_path, stat)
+            base_point, _, _ = _read_estimate(base_path, stat)
+            baseline_nalgebra_ns, baseline_faer_ns = _baseline_peer_times(group_dir, bench, baseline_name, stat)
+
+            speedup = base_point / new_point if new_point > 0 else float("inf")
+            pct_change = ((new_point - base_point) / base_point) * 100.0 if base_point > 0 else 0.0
+
+            comparisons.append(
+                Comparison(
+                    suite="vs_linalg",
+                    group=group_dir.name,
+                    bench=bench,
+                    baseline_ns=base_point,
+                    current_ns=new_point,
+                    speedup=speedup,
+                    pct_change=pct_change,
+                    baseline_nalgebra_ns=baseline_nalgebra_ns,
+                    baseline_faer_ns=baseline_faer_ns,
+                )
+            )
+
+    return comparisons
+
+
+def _collect_comparisons(
+    criterion_dir: Path,
+    baseline_name: str,
+    stat: str,
+    suite: str = "all",
+    scope: str = "release-signal",
+) -> list[Comparison]:
+    """Compare current (new) results against a named baseline."""
+    comparisons: list[Comparison] = []
+    if suite in ("all", "exact"):
+        comparisons.extend(_collect_exact_comparisons(criterion_dir, baseline_name, stat))
+    if suite in ("all", "vs_linalg"):
+        comparisons.extend(_collect_vs_linalg_comparisons(criterion_dir, baseline_name, stat, scope))
     return comparisons
 
 
@@ -202,7 +434,18 @@ def _format_pct(pct: float) -> str:
 
 class _GroupedItem(Protocol):
     @property
+    def suite(self) -> str: ...
+
+    @property
     def group(self) -> str: ...
+
+
+def _group_by_suite[T: _GroupedItem](items: list[T]) -> dict[str, list[T]]:
+    """Group results or comparisons by benchmark suite."""
+    suites: dict[str, list[T]] = {}
+    for item in items:
+        suites.setdefault(item.suite, []).append(item)
+    return suites
 
 
 def _group_by_group[T: _GroupedItem](items: list[T]) -> dict[str, list[T]]:
@@ -211,6 +454,15 @@ def _group_by_group[T: _GroupedItem](items: list[T]) -> dict[str, list[T]]:
     for item in items:
         groups.setdefault(item.group, []).append(item)
     return groups
+
+
+def _suite_heading(suite: str) -> str:
+    """Turn an internal suite name into a readable heading."""
+    if suite == "exact":
+        return "Exact arithmetic"
+    if suite == "vs_linalg":
+        return "vs_linalg"
+    return suite
 
 
 def _group_heading(group: str) -> str:
@@ -231,22 +483,33 @@ def _group_heading(group: str) -> str:
     return group
 
 
+def _group_heading_for_suite(suite: str, group: str) -> str:
+    """Turn a Criterion group name into a readable heading for its suite."""
+    if suite == "vs_linalg":
+        dim = _dim_from_vs_linalg_group(group)
+        if dim is not None:
+            return f"D={dim}"
+    return _group_heading(group)
+
+
 def _snapshot_tables(results: list[BenchResult], stat: str) -> str:
     """Generate per-dimension markdown tables for a single set of results."""
     stat_label = stat.capitalize()
     sections: list[str] = []
 
-    for group, items in _group_by_group(results).items():
-        lines = [
-            f"### {_group_heading(group)}",
-            "",
-            f"| Benchmark | {stat_label} | 95% CI |",
-            "|-----------|-------:|-------:|",
-        ]
-        for r in items:
-            ci_range = f"[{_format_time(r.ci_lo_ns)}, {_format_time(r.ci_hi_ns)}]"
-            lines.append(f"| {r.bench} | {_format_time(r.point_ns)} | {ci_range} |")
-        sections.append("\n".join(lines))
+    for suite, suite_items in _group_by_suite(results).items():
+        sections.append(f"## {_suite_heading(suite)}")
+        for group, items in _group_by_group(suite_items).items():
+            lines = [
+                f"### {_group_heading_for_suite(suite, group)}",
+                "",
+                f"| Benchmark | {stat_label} | 95% CI |",
+                "|-----------|-------:|-------:|",
+            ]
+            for r in items:
+                ci_range = f"[{_format_time(r.ci_lo_ns)}, {_format_time(r.ci_hi_ns)}]"
+                lines.append(f"| {r.bench} | {_format_time(r.point_ns)} | {ci_range} |")
+            sections.append("\n".join(lines))
 
     return "\n\n".join(sections)
 
@@ -255,16 +518,45 @@ def _comparison_tables(comparisons: list[Comparison], baseline_name: str) -> str
     """Generate per-dimension markdown tables comparing baseline vs current."""
     sections: list[str] = []
 
-    for group, items in _group_by_group(comparisons).items():
-        lines = [
-            f"### {_group_heading(group)}",
-            "",
-            f"| Benchmark | {baseline_name} | Current | Change | Speedup |",
-            "|-----------|-------:|--------:|-------:|--------:|",
-        ]
-        for c in items:
-            lines.append(f"| {c.bench} | {_format_time(c.baseline_ns)} | {_format_time(c.current_ns)} | {_format_pct(c.pct_change)} | {c.speedup:.2f}x |")
-        sections.append("\n".join(lines))
+    for suite, suite_items in _group_by_suite(comparisons).items():
+        sections.append(f"## {_suite_heading(suite)}")
+        for group, items in _group_by_group(suite_items).items():
+            has_peer_context = any(item.baseline_nalgebra_ns is not None or item.baseline_faer_ns is not None for item in items)
+            lines = [
+                f"### {_group_heading_for_suite(suite, group)}",
+                "",
+            ]
+            if has_peer_context:
+                lines.extend(
+                    [
+                        f"| Benchmark | {baseline_name} | Latest | Change | Speedup | {baseline_name} nalgebra | {baseline_name} faer |",
+                        "|-----------|-------:|-------:|-------:|--------:|-------:|-------:|",
+                    ]
+                )
+            else:
+                lines.extend(
+                    [
+                        f"| Benchmark | {baseline_name} | Latest | Change | Speedup |",
+                        "|-----------|-------:|-------:|-------:|--------:|",
+                    ]
+                )
+            for c in items:
+                cells = [
+                    c.bench,
+                    _format_time(c.baseline_ns),
+                    _format_time(c.current_ns),
+                    _format_pct(c.pct_change),
+                    f"{c.speedup:.2f}x",
+                ]
+                if has_peer_context:
+                    cells.extend(
+                        [
+                            _format_time(c.baseline_nalgebra_ns) if c.baseline_nalgebra_ns is not None else "",
+                            _format_time(c.baseline_faer_ns) if c.baseline_faer_ns is not None else "",
+                        ]
+                    )
+                lines.append(f"| {' | '.join(cells)} |")
+            sections.append("\n".join(lines))
 
     return "\n\n".join(sections)
 
@@ -302,26 +594,27 @@ def _get_git_info(root: Path) -> tuple[str, str]:
 def _generate_markdown(
     root: Path,
     table: str,
-    baseline_name: str | None,
-    stat: str,
+    settings: ReportSettings,
 ) -> str:
-    """Generate the complete PERFORMANCE.md content."""
+    """Generate the complete benchmark report content."""
     version = _read_cargo_version(root)
     short_hash, branch = _get_git_info(root)
     now = datetime.now(tz=UTC).strftime("%Y-%m-%d %H:%M:%S UTC")
 
     lines = [
-        "# Exact Arithmetic Performance",
+        "# Benchmark Performance",
         "",
         f"**la-stack** v{version} · `{short_hash}` ({branch}) · {now}",
-        f"**Statistic**: {stat}",
+        f"**Statistic**: {settings.stat}",
+        f"**Suite**: {settings.suite}",
+        f"**Scope**: {settings.scope}",
         "",
         "## Benchmark Results",
         "",
     ]
 
-    if baseline_name:
-        lines.append(f"Comparison against baseline **{baseline_name}**:")
+    if settings.baseline_name:
+        lines.append(f"Comparison against baseline **{settings.baseline_name}**:")
         lines.append("")
         lines.append("Negative change = faster. Speedup > 1.00x = improvement.")
     else:
@@ -334,14 +627,17 @@ def _generate_markdown(
             "## How to Update",
             "",
             "```bash",
-            "# Save a baseline at the current release",
-            "just bench-save-baseline <TAG>",
+            "# Save a full last-release baseline",
+            "just bench-save-last",
             "",
-            "# Compare current code against a saved baseline",
-            "just bench-compare <TAG>",
+            "# Run the cheaper latest measurements and compare against last",
+            "just bench-latest-vs-last",
+            "",
+            "# Re-render the report from existing Criterion output",
+            "just bench-compare",
             "",
             "# Generate a snapshot without comparison",
-            "just bench-compare",
+            "uv run bench-compare --snapshot",
             "```",
             "",
             "To compare against a *previous* release, check out the old tag first:",
@@ -350,7 +646,7 @@ def _generate_markdown(
             "git checkout v0.2.0",
             "just bench-save-baseline v0.2.0",
             "git checkout main",
-            "just bench-exact",
+            "just bench-latest",
             "just bench-compare v0.2.0",
             "```",
             "",
@@ -370,13 +666,18 @@ def _generate_markdown(
 
 def _parse_args(argv: list[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Compare exact-arithmetic benchmark results across Criterion baselines.",
+        description="Compare la-stack benchmark results across Criterion baselines.",
     )
     parser.add_argument(
         "baseline",
         nargs="?",
-        default=None,
-        help="Baseline name to compare against (e.g. 'v0.3.0'). Omit for a snapshot.",
+        default="last",
+        help="Baseline name to compare against (default: 'last').",
+    )
+    parser.add_argument(
+        "--snapshot",
+        action="store_true",
+        help="Generate a current-performance snapshot instead of comparing against a baseline.",
     )
     parser.add_argument(
         "--stat",
@@ -385,16 +686,44 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
         help="Statistic to compare (default: median).",
     )
     parser.add_argument(
+        "--suite",
+        default="all",
+        choices=SUITE_CHOICES,
+        help="Benchmark suite to compare (default: all).",
+    )
+    parser.add_argument(
+        "--scope",
+        default="release-signal",
+        choices=SCOPE_CHOICES,
+        help="Comparison scope: release-signal compares la-stack latest against last with baseline peer context; all-benches compares every present bench.",
+    )
+    parser.add_argument(
         "--criterion-dir",
         default="target/criterion",
         help="Criterion output directory (default: target/criterion).",
     )
     parser.add_argument(
         "--output",
-        default="docs/PERFORMANCE.md",
-        help="Output markdown file (default: docs/PERFORMANCE.md).",
+        default="target/bench-reports/performance.md",
+        help="Output markdown file (default: target/bench-reports/performance.md).",
     )
     return parser.parse_args(argv)
+
+
+def _run_bench_hint(suite: str) -> str:
+    if suite == "exact":
+        return "just bench-exact"
+    if suite == "vs_linalg":
+        return "just bench-vs-linalg-la-stack"
+    return "just bench-latest"
+
+
+def _save_baseline_hint(suite: str, baseline: str) -> str:
+    if suite == "exact":
+        return f"just bench-save-baseline {baseline} exact"
+    if suite == "vs_linalg":
+        return f"just bench-save-baseline {baseline} vs_linalg"
+    return f"just bench-save-baseline {baseline}"
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -406,33 +735,41 @@ def main(argv: list[str] | None = None) -> int:
 
     if not criterion_dir.is_dir():
         print(
-            f"No Criterion results found at {criterion_dir}.\nRun benchmarks first:\n  just bench-exact\n",
+            f"No Criterion results found at {criterion_dir}.\nRun benchmarks first:\n  {_run_bench_hint(args.suite)}\n",
             file=sys.stderr,
         )
         return 2
 
-    if args.baseline:
-        comparisons = _collect_comparisons(criterion_dir, args.baseline, args.stat)
+    baseline_name = None if args.snapshot else args.baseline
+
+    if baseline_name:
+        comparisons = _collect_comparisons(criterion_dir, baseline_name, args.stat, args.suite, args.scope)
         if not comparisons:
             print(
-                f"No comparison data found for baseline '{args.baseline}'.\n"
-                f"Save a baseline first:\n  just bench-save-baseline {args.baseline}\n"
-                "Then run benchmarks:\n  just bench-exact\n",
+                f"No comparison data found for baseline '{baseline_name}'.\n"
+                f"Save a baseline first:\n  {_save_baseline_hint(args.suite, baseline_name)}\n"
+                f"Then run benchmarks:\n  {_run_bench_hint(args.suite)}\n",
                 file=sys.stderr,
             )
             return 2
-        table = _comparison_tables(comparisons, args.baseline)
+        table = _comparison_tables(comparisons, baseline_name)
     else:
-        results = _collect_results(criterion_dir, "new", args.stat)
+        results = _collect_results(criterion_dir, "new", args.stat, args.suite)
         if not results:
             print(
-                "No benchmark results found.\nRun benchmarks first:\n  just bench-exact\n",
+                f"No benchmark results found.\nRun benchmarks first:\n  {_run_bench_hint(args.suite)}\n",
                 file=sys.stderr,
             )
             return 2
         table = _snapshot_tables(results, args.stat)
 
-    md = _generate_markdown(root, table, args.baseline, args.stat)
+    settings = ReportSettings(
+        baseline_name=baseline_name,
+        stat=args.stat,
+        suite=args.suite,
+        scope=args.scope,
+    )
+    md = _generate_markdown(root, table, settings)
 
     output_path.parent.mkdir(parents=True, exist_ok=True)
     output_path.write_text(md, encoding="utf-8")

--- a/scripts/tests/test_bench_compare.py
+++ b/scripts/tests/test_bench_compare.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import re
 from typing import TYPE_CHECKING
 
 import pytest
@@ -154,7 +155,10 @@ def test_read_estimate_malformed_json_names_file(tmp_path: Path) -> None:
     est = tmp_path / "estimates.json"
     est.write_text("{not json", encoding="utf-8")
 
-    with pytest.raises(ValueError, match=f"malformed Criterion estimates JSON in {est}"):
+    with pytest.raises(
+        ValueError,
+        match=re.escape(f"malformed Criterion estimates JSON in {est}"),
+    ):
         bench_compare._read_estimate(est, "median")
 
 

--- a/scripts/tests/test_bench_compare.py
+++ b/scripts/tests/test_bench_compare.py
@@ -41,6 +41,25 @@ def _build_criterion_tree(criterion_dir: Path, stat: str = "median") -> None:
     _write_estimates(random_group / "det_exact_p95" / "new" / "estimates.json", stat, 33000.0)
 
 
+def _build_vs_linalg_tree(criterion_dir: Path, stat: str = "median") -> None:
+    """Create fake Criterion vs_linalg data with latest la-stack and baseline peer rows."""
+    group = criterion_dir / "d2"
+
+    _write_estimates(group / "la_stack_lu_solve" / "new" / "estimates.json", stat, 10.0)
+    _write_estimates(group / "la_stack_lu_solve" / "last" / "estimates.json", stat, 20.0)
+    _write_estimates(group / "nalgebra_lu_solve" / "last" / "estimates.json", stat, 30.0)
+    _write_estimates(group / "faer_lu_solve" / "last" / "estimates.json", stat, 40.0)
+
+    _write_estimates(group / "la_stack_ldlt_solve" / "new" / "estimates.json", stat, 12.0)
+    _write_estimates(group / "la_stack_ldlt_solve" / "last" / "estimates.json", stat, 24.0)
+    _write_estimates(group / "nalgebra_cholesky_solve" / "last" / "estimates.json", stat, 36.0)
+    _write_estimates(group / "faer_ldlt_solve" / "last" / "estimates.json", stat, 48.0)
+
+    # Present only in the baseline; release-signal comparison should not require
+    # latest third-party measurements.
+    _write_estimates(group / "nalgebra_lu_solve" / "new" / "estimates.json", stat, 31.0)
+
+
 # ---------------------------------------------------------------------------
 # Unit tests for formatting helpers
 # ---------------------------------------------------------------------------
@@ -131,6 +150,40 @@ def test_read_estimate_missing_stat(tmp_path: Path) -> None:
         bench_compare._read_estimate(est, "mean")
 
 
+def test_read_estimate_malformed_json_names_file(tmp_path: Path) -> None:
+    est = tmp_path / "estimates.json"
+    est.write_text("{not json", encoding="utf-8")
+
+    with pytest.raises(ValueError, match=f"malformed Criterion estimates JSON in {est}"):
+        bench_compare._read_estimate(est, "median")
+
+
+def test_read_estimate_missing_point_estimate_names_field(tmp_path: Path) -> None:
+    est = tmp_path / "estimates.json"
+    est.write_text(json.dumps({"median": {}}), encoding="utf-8")
+
+    with pytest.raises(KeyError, match="field 'point_estimate' for stat 'median' not found"):
+        bench_compare._read_estimate(est, "median")
+
+
+def test_read_estimate_non_numeric_ci_bound_names_field(tmp_path: Path) -> None:
+    est = tmp_path / "estimates.json"
+    est.write_text(
+        json.dumps(
+            {
+                "median": {
+                    "point_estimate": 1.0,
+                    "confidence_interval": {"lower_bound": "fast", "upper_bound": 2.0},
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match=r"field 'lower_bound' for stat 'median'.*not numeric"):
+        bench_compare._read_estimate(est, "median")
+
+
 # ---------------------------------------------------------------------------
 # collect_results / collect_comparisons
 # ---------------------------------------------------------------------------
@@ -187,6 +240,33 @@ def test_collect_comparisons_missing_baseline(tmp_path: Path) -> None:
     assert comparisons == []
 
 
+def test_collect_vs_linalg_release_signal_uses_baseline_peer_context(tmp_path: Path) -> None:
+    _build_vs_linalg_tree(tmp_path)
+    comparisons = bench_compare._collect_comparisons(tmp_path, "last", "median")
+
+    assert [c.bench for c in comparisons] == ["la_stack_lu_solve", "la_stack_ldlt_solve"]
+    lu = comparisons[0]
+    assert lu.baseline_ns == 20.0
+    assert lu.current_ns == 10.0
+    assert lu.baseline_nalgebra_ns == 30.0
+    assert lu.baseline_faer_ns == 40.0
+
+    ldlt = comparisons[1]
+    assert ldlt.baseline_nalgebra_ns == 36.0
+    assert ldlt.baseline_faer_ns == 48.0
+
+
+def test_collect_vs_linalg_all_benches_includes_latest_peer_rows(tmp_path: Path) -> None:
+    _build_vs_linalg_tree(tmp_path)
+    comparisons = bench_compare._collect_comparisons(tmp_path, "last", "median", scope="all-benches")
+
+    assert [c.bench for c in comparisons] == [
+        "la_stack_lu_solve",
+        "nalgebra_lu_solve",
+        "la_stack_ldlt_solve",
+    ]
+
+
 # ---------------------------------------------------------------------------
 # Table generation
 # ---------------------------------------------------------------------------
@@ -222,7 +302,17 @@ def test_comparison_tables_per_dimension(tmp_path: Path) -> None:
     tables = bench_compare._comparison_tables(comparisons, "v0.3.0")
     assert "### D=2" in tables
     assert "### D=3" in tables
-    assert "| Benchmark | v0.3.0 | Current | Change | Speedup |" in tables
+    assert "| Benchmark | v0.3.0 | Latest | Change | Speedup |" in tables
+
+
+def test_comparison_tables_include_vs_linalg_peer_context(tmp_path: Path) -> None:
+    _build_vs_linalg_tree(tmp_path)
+    comparisons = bench_compare._collect_comparisons(tmp_path, "last", "median")
+    tables = bench_compare._comparison_tables(comparisons, "last")
+
+    assert "| Benchmark | last | Latest | Change | Speedup | last nalgebra | last faer |" in tables
+    assert "| la_stack_lu_solve | 20.0 ns | 10.0 ns | **-50.0%** | 2.00x | 30.0 ns | 40.0 ns |" in tables
+    assert "| la_stack_ldlt_solve | 24.0 ns | 12.0 ns | **-50.0%** | 2.00x | 36.0 ns | 48.0 ns |" in tables
 
 
 # ---------------------------------------------------------------------------
@@ -235,7 +325,7 @@ def test_main_snapshot_writes_output(tmp_path: Path) -> None:
     _build_criterion_tree(criterion_dir)
     output = tmp_path / "PERFORMANCE.md"
 
-    rc = bench_compare.main(["--criterion-dir", str(criterion_dir), "--output", str(output)])
+    rc = bench_compare.main(["--snapshot", "--criterion-dir", str(criterion_dir), "--output", str(output)])
     assert rc == 0
     assert output.exists()
 

--- a/tests/vs_linalg_inputs.rs
+++ b/tests/vs_linalg_inputs.rs
@@ -1,0 +1,185 @@
+//! Smoke tests for the deterministic inputs used by the `vs_linalg` benchmark.
+
+#![cfg(feature = "bench")]
+
+use faer::linalg::solvers::Solve;
+use faer::{Mat, Side};
+use nalgebra::{SMatrix, SVector};
+
+use la_stack::{DEFAULT_PIVOT_TOL, DEFAULT_SINGULAR_TOL, Matrix, Vector};
+
+#[path = "../benches/common/vs_linalg.rs"]
+mod vs_linalg;
+
+use vs_linalg::{
+    faer_det_from_ldlt, faer_det_from_partial_piv_lu, make_matrix_rows, make_vector_array,
+    matrix_entry, nalgebra_inf_norm, vector_entry,
+};
+
+/// Assert scalar agreement with a tolerance that scales for larger magnitudes.
+fn assert_close(label: &str, actual: f64, expected: f64) {
+    let scale = actual.abs().max(expected.abs()).max(1.0);
+    let diff = (actual - expected).abs();
+    assert!(
+        diff <= 1.0e-9 * scale,
+        "{label}: actual={actual:?}, expected={expected:?}, diff={diff:?}, scale={scale:?}",
+    );
+}
+
+/// Assert componentwise agreement for fixed-size vector results from peer crates.
+fn assert_vector_close<const D: usize>(label: &str, actual: [f64; D], expected: [f64; D]) {
+    for i in 0..D {
+        assert_close(&format!("{label}[{i}]"), actual[i], expected[i]);
+    }
+}
+
+/// Copy a faer single-column solve result into an array for componentwise checks.
+fn faer_column_to_array<const D: usize>(m: &Mat<f64>) -> [f64; D] {
+    let mut data = [0.0; D];
+    for i in 0..D {
+        data[i] = m[(i, 0)];
+    }
+    data
+}
+
+/// Copy a nalgebra stack vector into an array for componentwise checks.
+fn nalgebra_vector_to_array<const D: usize>(v: &SVector<f64, D>) -> [f64; D] {
+    let mut data = [0.0; D];
+    data.copy_from_slice(v.as_slice());
+    data
+}
+
+/// Generate one cross-crate smoke test for a concrete benchmark dimension.
+macro_rules! gen_smoke_test {
+    ($name:ident, $d:literal) => {
+        #[test]
+        #[allow(clippy::too_many_lines)]
+        fn $name() {
+            let a = Matrix::<$d>::try_from_rows(make_matrix_rows::<$d>())
+                .unwrap_or_else(|err| panic!("la_stack matrix construction failed: {err}"));
+            let rhs = Vector::<$d>::try_new(make_vector_array::<$d>(0.0))
+                .unwrap_or_else(|err| panic!("la_stack RHS vector construction failed: {err}"));
+            let v1 = Vector::<$d>::try_new(make_vector_array::<$d>(0.0))
+                .unwrap_or_else(|err| panic!("la_stack vector construction failed: {err}"));
+            let v2 = Vector::<$d>::try_new(make_vector_array::<$d>(1.0))
+                .unwrap_or_else(|err| panic!("la_stack vector construction failed: {err}"));
+
+            let na = SMatrix::<f64, $d, $d>::from_fn(|r, c| matrix_entry::<$d>(r, c));
+            let nrhs = SVector::<f64, $d>::from_fn(|i, _| vector_entry(i, 0.0));
+            let nv1 = SVector::<f64, $d>::from_fn(|i, _| vector_entry(i, 0.0));
+            let nv2 = SVector::<f64, $d>::from_fn(|i, _| vector_entry(i, 1.0));
+
+            let fa = Mat::<f64>::from_fn($d, $d, |r, c| matrix_entry::<$d>(r, c));
+            let frhs = Mat::<f64>::from_fn($d, 1, |i, _| vector_entry(i, 0.0));
+            let fv1 = Mat::<f64>::from_fn($d, 1, |i, _| vector_entry(i, 0.0));
+            let fv2 = Mat::<f64>::from_fn($d, 1, |i, _| vector_entry(i, 1.0));
+
+            let la_lu = a
+                .lu(DEFAULT_PIVOT_TOL)
+                .unwrap_or_else(|err| panic!("la_stack LU factorization failed: {err}"));
+            let na_lu = na.lu();
+            let fa_lu = fa.partial_piv_lu();
+
+            let la_lu_det = la_lu
+                .det()
+                .unwrap_or_else(|err| panic!("la_stack LU determinant failed: {err}"));
+            assert_close("nalgebra_det_from_lu", na_lu.determinant(), la_lu_det);
+            assert_close(
+                "faer_det_from_lu",
+                faer_det_from_partial_piv_lu(&fa_lu),
+                la_lu_det,
+            );
+
+            let la_lu_x = la_lu
+                .solve_vec(rhs)
+                .unwrap_or_else(|err| panic!("la_stack LU solve failed: {err}"));
+            let na_lu_x = na_lu
+                .solve(&nrhs)
+                .unwrap_or_else(|| panic!("nalgebra LU solve returned no result"));
+            let fa_lu_x = fa_lu.solve(&frhs);
+            let la_lu_x = la_lu_x.into_array();
+            assert_vector_close(
+                "nalgebra_solve_from_lu",
+                nalgebra_vector_to_array(&na_lu_x),
+                la_lu_x,
+            );
+            assert_vector_close(
+                "faer_solve_from_lu",
+                faer_column_to_array(&fa_lu_x),
+                la_lu_x,
+            );
+
+            let la_ldlt = a
+                .ldlt(DEFAULT_SINGULAR_TOL)
+                .unwrap_or_else(|err| panic!("la_stack LDLT factorization failed: {err}"));
+            let na_cholesky = na
+                .cholesky()
+                .unwrap_or_else(|| panic!("nalgebra Cholesky factorization returned no result"));
+            let fa_ldlt = fa
+                .ldlt(Side::Lower)
+                .unwrap_or_else(|err| panic!("faer LDLT factorization failed: {err}"));
+
+            let la_ldlt_det = la_ldlt
+                .det()
+                .unwrap_or_else(|err| panic!("la_stack LDLT determinant failed: {err}"));
+            assert_close(
+                "nalgebra_det_from_cholesky",
+                na_cholesky.determinant(),
+                la_ldlt_det,
+            );
+            assert_close(
+                "faer_det_from_ldlt",
+                faer_det_from_ldlt(&fa_ldlt),
+                la_ldlt_det,
+            );
+
+            let la_ldlt_x = la_ldlt
+                .solve_vec(rhs)
+                .unwrap_or_else(|err| panic!("la_stack LDLT solve failed: {err}"));
+            let na_cholesky_x = na_cholesky.solve(&nrhs);
+            let fa_ldlt_x = fa_ldlt.solve(&frhs);
+            let la_ldlt_x = la_ldlt_x.into_array();
+            assert_vector_close(
+                "nalgebra_solve_from_cholesky",
+                nalgebra_vector_to_array(&na_cholesky_x),
+                la_ldlt_x,
+            );
+            assert_vector_close(
+                "faer_solve_from_ldlt",
+                faer_column_to_array(&fa_ldlt_x),
+                la_ldlt_x,
+            );
+
+            let la_dot = v1
+                .dot(v2)
+                .unwrap_or_else(|err| panic!("la_stack dot failed: {err}"));
+            assert_close("nalgebra_dot", nv1.dot(&nv2), la_dot);
+            let mut fa_dot = 0.0;
+            for i in 0..$d {
+                fa_dot = fv1[(i, 0)].mul_add(fv2[(i, 0)], fa_dot);
+            }
+            assert_close("faer_dot", fa_dot, la_dot);
+
+            let la_norm = a
+                .inf_norm()
+                .unwrap_or_else(|err| panic!("la_stack inf_norm failed: {err}"));
+            assert_close("nalgebra_inf_norm", nalgebra_inf_norm(&na), la_norm);
+            let mut fa_norm = 0.0;
+            for r in 0..$d {
+                let mut row_sum = 0.0;
+                for c in 0..$d {
+                    row_sum += fa[(r, c)].abs();
+                }
+                if row_sum > fa_norm {
+                    fa_norm = row_sum;
+                }
+            }
+            assert_close("faer_inf_norm", fa_norm, la_norm);
+        }
+    };
+}
+
+gen_smoke_test!(vs_linalg_shared_inputs_agree_2d, 2);
+gen_smoke_test!(vs_linalg_shared_inputs_agree_3d, 3);
+gen_smoke_test!(vs_linalg_shared_inputs_agree_4d, 4);
+gen_smoke_test!(vs_linalg_shared_inputs_agree_5d, 5);


### PR DESCRIPTION
- Extend vs_linalg with LDLT/Cholesky benchmark rows and shared deterministic inputs.
- Add smoke coverage that checks la-stack, nalgebra, and faer agree on benchmark inputs.
- Expand bench-compare to support latest-vs-last reports, suite/scope selection, peer baseline context, and clearer malformed Criterion diagnostics.
- Document the benchmark methodology, release baseline workflow, roadmap direction, and contributor guidance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive contribution guidelines and AI-assisted workflow
  * Updated README with feature flags and clearer usage guidance
  * Expanded benchmarking and releasing docs with updated workflows and methodology

* **Tests**
  * Added deterministic smoke tests to validate results across math implementations

* **Chores / Tooling**
  * Improved benchmark comparison tooling and CLI (suite/scope/snapshot support, latest-vs-last)
  * Enhanced benchmark report formatting and baseline workflows
<!-- end of auto-generated comment: release notes by coderabbit.ai -->