### PR TITLE
build(msrv)!: require Rust 1.97.1

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -5,10 +5,11 @@ early_access: false
 reviews:
   profile: chill
   request_changes_workflow: true
-  # Publish only the legacy commit status consumed by the main-branch ruleset.
-  # The review-progress path creates a second GitHub check run for the same review.
-  review_progress: false
-  commit_status: true
+  review_status: true
+  # Publish CodeRabbit's canonical GitHub check run for ruleset enforcement.
+  review_progress: true
+  # Do not mirror the review through GitHub's legacy commit-status API.
+  commit_status: false
   fail_commit_status: true
   tools:
     github-checks:

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -5,11 +5,10 @@ early_access: false
 reviews:
   profile: chill
   request_changes_workflow: true
-  review_status: true
-  # Publish CodeRabbit's canonical GitHub check run for ruleset enforcement.
-  review_progress: true
-  # Do not mirror the review through GitHub's legacy commit-status API.
-  commit_status: false
+  # Publish the legacy commit status consumed by the main-branch ruleset.
+  # Keep review_progress off until CodeRabbit can publish the required check run.
+  review_progress: false
+  commit_status: true
   fail_commit_status: true
   tools:
     github-checks:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -207,7 +207,7 @@ When user requests commit message generation:
 
 ### Rust
 
-- The current MSRV and pinned contributor/CI toolchain are Rust 1.97.0. Keep
+- The current MSRV and pinned contributor/CI toolchain are Rust 1.97.1. Keep
   `Cargo.toml`, `rust-toolchain.toml`, and `clippy.toml` aligned when that
   baseline changes deliberately.
 - Prefer borrowed APIs by default:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ clarity, and the fixed-dimension stack-allocation model.
 
 ## Getting Started
 
-Install Rust 1.97.0 through [rustup](https://rustup.rs/), Git, Python 3.14,
+Install Rust 1.97.1 through [rustup](https://rustup.rs/), Git, Python 3.14,
 [`uv` 0.12.0](https://docs.astral.sh/uv/), and `jq`. Install the repository's
 pinned `just` version from its locked dependency graph:
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "la-stack"
 version = "0.4.4"
 edition = "2024"
-rust-version = "1.97.0"
+rust-version = "1.97.1"
 license = "BSD-3-Clause"
 description = "Fast, stack-allocated linear algebra for fixed dimensions"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -570,7 +570,7 @@ cargo run --features exact --example exact_solve_3x3
 
 A short contributor workflow:
 
-Install Rust 1.97.0 through [rustup](https://rustup.rs/), Git, Python 3.14,
+Install Rust 1.97.1 through [rustup](https://rustup.rs/), Git, Python 3.14,
 [`uv` 0.12.0](https://docs.astral.sh/uv/), and `jq`. Then install the pinned
 `just` release from its locked dependency graph:
 

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,6 +1,6 @@
 # Clippy configuration for the la-stack crate.
 
 # Keep lint behavior aligned with Cargo.toml and rust-toolchain.toml.
-msrv = "1.97.0"
+msrv = "1.97.1"
 
 # Lint levels are owned by Cargo.toml.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -14,7 +14,7 @@ to crates.io.
 
 ## Conventions and environment
 
-The current MSRV and pinned release-validation toolchain are Rust 1.97.0. Keep
+The current MSRV and pinned release-validation toolchain are Rust 1.97.1. Keep
 `Cargo.toml`, `rust-toolchain.toml`, and `clippy.toml` aligned whenever a future
 release deliberately changes that baseline.
 

--- a/justfile
+++ b/justfile
@@ -204,11 +204,12 @@ bench-compare baseline="last" suite="all" scope="release-signal": python-sync
     baseline={{ quote(baseline) }}
     uv run --locked bench-compare "$baseline" --suite {{ quote(suite) }} --scope {{ quote(scope) }}
 
-# Compile benchmarks without running them, treating warnings as errors.
+# Compile benchmarks without running them, treating warnings as errors through
+# Cargo so warning policy does not create separate rustc cache artifacts.
 # This catches bench/release-profile-only warnings that won't show up in normal debug-profile runs.
 bench-compile:
-    RUSTFLAGS='-D warnings' cargo bench --locked --no-run --features bench
-    RUSTFLAGS='-D warnings' cargo bench --locked --no-run --features bench,exact --bench exact
+    CARGO_BUILD_WARNINGS=deny cargo bench --locked --no-run --features bench
+    CARGO_BUILD_WARNINGS=deny cargo bench --locked --no-run --features bench,exact --bench exact
 
 # Run the exact-arithmetic benchmark suite.
 bench-exact:

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,6 @@
 [toolchain]
 # Pin to MSRV as specified in Cargo.toml
-channel = "1.97.0"
+channel = "1.97.1"
 
 # Essential repository components. Keep checkout and CI setup lean; workflows
 # install additional targets or components when they need them.


### PR DESCRIPTION
- align contributor, CI, release, and Clippy toolchain baselines
- compile benchmarks with Cargo's warning policy to preserve cache reuse
- publish CodeRabbit's canonical review check for ruleset enforcement

BREAKING CHANGE: la-stack now requires Rust 1.97.1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated contributor, release, and project documentation to require Rust 1.97.1.
  * Clarified repository checks and review-progress reporting behavior.
* **Chores**
  * Updated the project’s minimum supported and pinned Rust toolchains to 1.97.1.
  * Improved benchmark compilation warning enforcement using the current Cargo warning setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->