### PR TITLE
ci: standardize validation and centralize tool pins

### DIFF
--- a/.github/actions/setup-just/action.yml
+++ b/.github/actions/setup-just/action.yml
@@ -1,0 +1,51 @@
+name: Set up just
+description: Resolve the pinned just version from justfile and install it.
+
+outputs:
+  version:
+    description: Resolved just version from justfile.
+    value: ${{ steps.resolve.outputs.version }}
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve just version
+      id: resolve
+      shell: bash
+      run: |
+        set -euo pipefail
+        shopt -s extglob
+
+        version=""
+        declaration_re='^[[:space:]]*just_version[[:space:]]*:=[[:space:]]*(.*)$'
+        while IFS= read -r line; do
+          if [[ "$line" =~ $declaration_re ]]; then
+            value="${BASH_REMATCH[1]}"
+            value="${value%%#*}"
+            value="${value##+([[:space:]])}"
+            value="${value%%+([[:space:]])}"
+
+            if [[ ${#value} -ge 2 ]]; then
+              first="${value:0:1}"
+              last="${value: -1}"
+              if [[ "$first" == "$last" && ( "$first" == '"' || "$first" == "'" ) ]]; then
+                value="${value:1:${#value}-2}"
+              fi
+            fi
+
+            version="$value"
+            break
+          fi
+        done < justfile
+
+        if [[ -z "$version" ]]; then
+          echo "::error::Could not resolve just_version from justfile"
+          exit 1
+        fi
+
+        echo "version=$version" >> "$GITHUB_OUTPUT"
+
+    - name: Install just
+      uses: taiki-e/cache-cargo-install-action@417450f3c33ee20393705369577571770643d4c7 # v3.0.7
+      with:
+        tool: just@${{ steps.resolve.outputs.version }}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "monday"
+      time: "03:00"
+      timezone: "America/Los_Angeles"
     cooldown:
       default-days: 7
     open-pull-requests-limit: 10
@@ -21,6 +24,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "monday"
+      time: "04:00"
+      timezone: "America/Los_Angeles"
     cooldown:
       default-days: 7
     open-pull-requests-limit: 10
@@ -38,6 +44,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "monday"
+      time: "05:00"
+      timezone: "America/Los_Angeles"
     cooldown:
       default-days: 7
     open-pull-requests-limit: 10

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -87,7 +87,7 @@ jobs:
             github.event_name != 'pull_request' ||
             github.event.pull_request.head.repo.full_name == github.repository
           )
-        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         with:
           sarif_file: audit-results.sarif
           category: cargo-audit

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -23,6 +23,7 @@ on:
       - "Cargo.lock"
       - "justfile"
       - "rust-toolchain.toml"
+      - ".github/actions/setup-just/action.yml"
       - ".github/workflows/benchmarks.yml"
   pull_request:
     branches:
@@ -37,6 +38,7 @@ on:
       - "Cargo.lock"
       - "justfile"
       - "rust-toolchain.toml"
+      - ".github/actions/setup-just/action.yml"
       - ".github/workflows/benchmarks.yml"
   workflow_dispatch:
 
@@ -69,21 +71,21 @@ jobs:
           cache: true
           cache-bin: false
 
-      - name: Read just version
-        id: just_version
-        run: |
-          version="$(grep '^just_version :=' justfile | cut -d '"' -f 2)"
-          echo "version=$version" >> "$GITHUB_OUTPUT"
+      - name: Set up just
+        uses: ./.github/actions/setup-just
 
-      - name: Install just
-        uses: taiki-e/cache-cargo-install-action@417450f3c33ee20393705369577571770643d4c7 # v3.0.7
-        with:
-          tool: just@${{ steps.just_version.outputs.version }}
-
-      - name: Read cargo-nextest version
+      - name: Resolve cargo-nextest version
         id: cargo_nextest_version
+        shell: bash
         run: |
+          set -euo pipefail
+
           version="$(just --evaluate cargo_nextest_version)"
+          if [[ -z "$version" ]]; then
+            echo "::error::Could not resolve cargo_nextest_version from justfile"
+            exit 1
+          fi
+
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
       - name: Install cargo-nextest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,31 +63,49 @@ jobs:
           cache-bin: false
           # toolchain, components, etc. are specified in rust-toolchain.toml
 
-      - name: Read just version
-        id: just_version
-        shell: bash
-        run: |
-          version="$(grep '^just_version :=' justfile | cut -d '"' -f 2)"
-          echo "version=$version" >> "$GITHUB_OUTPUT"
-
-      - name: Install just
-        uses: taiki-e/cache-cargo-install-action@417450f3c33ee20393705369577571770643d4c7 # v3.0.7
-        with:
-          tool: just@${{ steps.just_version.outputs.version }}
+      - name: Set up just
+        uses: ./.github/actions/setup-just
 
       - name: Export tool versions
         id: tool_versions
         shell: bash
         run: |
+          set -euo pipefail
+
+          resolve_version() {
+            local name="$1"
+            local value
+
+            if ! value="$(just --evaluate "$name")"; then
+              echo "::error::Failed to resolve $name from justfile" >&2
+              return 1
+            fi
+            if [[ -z "$value" ]]; then
+              echo "::error::Resolved empty $name from justfile" >&2
+              return 1
+            fi
+
+            printf '%s\n' "$value"
+          }
+
+          cargo_machete_version="$(resolve_version cargo_machete_version)"
+          cargo_nextest_version="$(resolve_version cargo_nextest_version)"
+          dprint_version="$(resolve_version dprint_version)"
+          rumdl_version="$(resolve_version rumdl_version)"
+          taplo_version="$(resolve_version taplo_version)"
+          typos_version="$(resolve_version typos_version)"
+          uv_version="$(resolve_version uv_version)"
+          zizmor_version="$(resolve_version zizmor_version)"
+
           {
-            echo "CARGO_MACHETE_VERSION=$(just --evaluate cargo_machete_version)"
-            echo "CARGO_NEXTEST_VERSION=$(just --evaluate cargo_nextest_version)"
-            echo "DPRINT_VERSION=$(just --evaluate dprint_version)"
-            echo "RUMDL_VERSION=$(just --evaluate rumdl_version)"
-            echo "TAPLO_VERSION=$(just --evaluate taplo_version)"
-            echo "TYPOS_VERSION=$(just --evaluate typos_version)"
-            echo "UV_VERSION=$(just --evaluate uv_version)"
-            echo "ZIZMOR_VERSION=$(just --evaluate zizmor_version)"
+            echo "CARGO_MACHETE_VERSION=$cargo_machete_version"
+            echo "CARGO_NEXTEST_VERSION=$cargo_nextest_version"
+            echo "DPRINT_VERSION=$dprint_version"
+            echo "RUMDL_VERSION=$rumdl_version"
+            echo "TAPLO_VERSION=$taplo_version"
+            echo "TYPOS_VERSION=$typos_version"
+            echo "UV_VERSION=$uv_version"
+            echo "ZIZMOR_VERSION=$zizmor_version"
           } >> "$GITHUB_OUTPUT"
 
       - name: Set up Python

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -31,23 +31,37 @@ jobs:
           cache: true # toolchain/components are specified in rust-toolchain.toml
           cache-bin: false
 
-      - name: Read just version
-        id: just_version
-        run: |
-          version="$(grep '^just_version :=' justfile | cut -d '"' -f 2)"
-          echo "version=$version" >> "$GITHUB_OUTPUT"
-
-      - name: Install just
-        uses: taiki-e/cache-cargo-install-action@417450f3c33ee20393705369577571770643d4c7 # v3.0.7
-        with:
-          tool: just@${{ steps.just_version.outputs.version }}
+      - name: Set up just
+        uses: ./.github/actions/setup-just
 
       - name: Export coverage tool versions
         id: tool_versions
+        shell: bash
         run: |
+          set -euo pipefail
+
+          resolve_version() {
+            local name="$1"
+            local value
+
+            if ! value="$(just --evaluate "$name")"; then
+              echo "::error::Failed to resolve $name from justfile" >&2
+              return 1
+            fi
+            if [[ -z "$value" ]]; then
+              echo "::error::Resolved empty $name from justfile" >&2
+              return 1
+            fi
+
+            printf '%s\n' "$value"
+          }
+
+          cargo_llvm_cov_version="$(resolve_version cargo_llvm_cov_version)"
+          cargo_nextest_version="$(resolve_version cargo_nextest_version)"
+
           {
-            echo "CARGO_LLVM_COV_VERSION=$(just --evaluate cargo_llvm_cov_version)"
-            echo "CARGO_NEXTEST_VERSION=$(just --evaluate cargo_nextest_version)"
+            echo "CARGO_LLVM_COV_VERSION=$cargo_llvm_cov_version"
+            echo "CARGO_NEXTEST_VERSION=$cargo_nextest_version"
           } >> "$GITHUB_OUTPUT"
 
       - name: Install LLVM coverage tools

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -35,20 +35,20 @@ jobs:
 
       - name: Initialize CodeQL
         if: matrix.language != 'rust'
-        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         with:
           languages: ${{ matrix.language }}
           queries: security-extended
 
       - name: Initialize CodeQL (Rust)
         if: matrix.language == 'rust'
-        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         with:
           languages: ${{ matrix.language }}
           build-mode: none
           queries: security-extended
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/release-benchmarks.yml
+++ b/.github/workflows/release-benchmarks.yml
@@ -38,14 +38,27 @@ jobs:
         with:
           cache: false
 
-      - name: Install benchmark validation tools
+      - name: Set up just
+        uses: ./.github/actions/setup-just
+
+      - name: Resolve cargo-nextest version
+        id: cargo_nextest_version
+        shell: bash
         run: |
           set -euo pipefail
 
-          just_version="$(grep '^just_version :=' justfile | cut -d '"' -f 2)"
-          cargo install --locked just --version "$just_version"
-          nextest_version="$(just --evaluate cargo_nextest_version)"
-          cargo install --locked cargo-nextest --version "$nextest_version"
+          version="$(just --evaluate cargo_nextest_version)"
+          if [[ -z "$version" ]]; then
+            echo "::error::Could not resolve cargo_nextest_version from justfile"
+            exit 1
+          fi
+
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Install cargo-nextest
+        uses: taiki-e/cache-cargo-install-action@417450f3c33ee20393705369577571770643d4c7 # v3.0.7
+        with:
+          tool: cargo-nextest@${{ steps.cargo_nextest_version.outputs.version }}
 
       - name: Validate benchmark inputs
         run: just test-bench-inputs

--- a/.github/workflows/rust-clippy.yml
+++ b/.github/workflows/rust-clippy.yml
@@ -28,9 +28,6 @@ jobs:
   clippy-sarif:
     name: Clippy SARIF Analysis
     runs-on: ubuntu-latest
-    env:
-      CLIPPY_SARIF_VERSION: "0.8.0"
-      SARIF_FMT_VERSION: "0.8.0"
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -43,15 +40,48 @@ jobs:
           cache: true # toolchain/components are specified in rust-toolchain.toml
           cache-bin: false
 
+      - name: Set up just
+        uses: ./.github/actions/setup-just
+
+      - name: Export tool versions
+        id: tool_versions
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          resolve_version() {
+            local name="$1"
+            local value
+
+            if ! value="$(just --evaluate "$name")"; then
+              echo "::error::Failed to resolve $name from justfile" >&2
+              return 1
+            fi
+            if [[ -z "$value" ]]; then
+              echo "::error::Resolved empty $name from justfile" >&2
+              return 1
+            fi
+
+            printf '%s\n' "$value"
+          }
+
+          clippy_sarif_version="$(resolve_version clippy_sarif_version)"
+          sarif_fmt_version="$(resolve_version sarif_fmt_version)"
+
+          {
+            echo "CLIPPY_SARIF_VERSION=$clippy_sarif_version"
+            echo "SARIF_FMT_VERSION=$sarif_fmt_version"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Install clippy-sarif
         uses: taiki-e/cache-cargo-install-action@417450f3c33ee20393705369577571770643d4c7 # v3.0.7
         with:
-          tool: clippy-sarif@${{ env.CLIPPY_SARIF_VERSION }}
+          tool: clippy-sarif@${{ steps.tool_versions.outputs.CLIPPY_SARIF_VERSION }}
 
       - name: Install sarif-fmt
         uses: taiki-e/cache-cargo-install-action@417450f3c33ee20393705369577571770643d4c7 # v3.0.7
         with:
-          tool: sarif-fmt@${{ env.SARIF_FMT_VERSION }}
+          tool: sarif-fmt@${{ steps.tool_versions.outputs.SARIF_FMT_VERSION }}
 
       - name: Run clippy with SARIF output
         run: |
@@ -74,7 +104,7 @@ jobs:
             github.event_name != 'pull_request'
             || github.event.pull_request.head.repo.full_name == github.repository
           )
-        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         with:
           sarif_file: rust-clippy-results.sarif
           category: "clippy"

--- a/.github/workflows/semgrep-sarif.yml
+++ b/.github/workflows/semgrep-sarif.yml
@@ -34,10 +34,21 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Read uv version
+      - name: Set up just
+        uses: ./.github/actions/setup-just
+
+      - name: Resolve uv version
         id: uv_version
+        shell: bash
         run: |
-          version="$(grep '^uv_version :=' justfile | cut -d '"' -f 2)"
+          set -euo pipefail
+
+          version="$(just --evaluate uv_version)"
+          if [[ -z "$version" ]]; then
+            echo "::error::Could not resolve uv_version from justfile"
+            exit 1
+          fi
+
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
       - name: Install uv
@@ -70,7 +81,7 @@ jobs:
             github.event_name != 'pull_request' ||
             github.event.pull_request.head.repo.full_name == github.repository
           )
-        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         with:
           sarif_file: semgrep-results.sarif
           category: semgrep-repository-rules

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -33,6 +33,6 @@ jobs:
           persist-credentials: false
 
       - name: Run zizmor
-        uses: zizmorcore/zizmor-action@6fc4b006235f201fdab3722e17240ab420d580e5 # v0.6.1
+        uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2
         with:
           inputs: .github

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,11 +7,11 @@ clarity, and the fixed-dimension stack-allocation model.
 ## Getting Started
 
 Install Rust 1.97.1 through [rustup](https://rustup.rs/), Git, Python 3.14,
-[`uv` 0.12.0](https://docs.astral.sh/uv/), and `jq`. Install the repository's
+[`uv` 0.12.1](https://docs.astral.sh/uv/), and `jq`. Install the repository's
 pinned `just` version from its locked dependency graph:
 
 ```bash
-cargo install --locked just --version 1.56.0
+cargo install --locked just --version 1.57.0
 ```
 
 Set up the remaining development tools and validate the checkout:
@@ -35,6 +35,34 @@ an explicit allowlist, and kept with readable version comments for review.
 
 CI runs `just ci` on Ubuntu, macOS, and Windows to keep platform coverage
 aligned with the local comprehensive validation path.
+
+### Rust Toolchain Policy
+
+The `bench-compile` recipe uses Cargo's `CARGO_BUILD_WARNINGS=deny` policy for
+both the normal benchmark feature and the `exact` benchmark target. Unlike a
+global `RUSTFLAGS='-D warnings'`, this denies lint warnings only for local
+packages without changing rustc arguments and creating separate cache
+artifacts. Rustdoc has a separate warning contract, so `doc-check` continues to
+set `RUSTDOCFLAGS='-D warnings'` for the default and `exact` documentation
+surfaces. See the [Rust 1.97 release notes](https://doc.rust-lang.org/stable/releases.html#version-1970-2026-07-09)
+and [Cargo configuration reference](https://doc.rust-lang.org/cargo/reference/config.html#buildwarnings).
+
+The remaining Rust 1.97 tooling changes require no repository configuration:
+
+- Rust's default v0 symbol mangling is accepted. Repository code, benchmark
+  reporting, and support scripts do not parse raw Rust symbols or require the
+  legacy format. Any future symbol-processing tool must support v0 rather than
+  forcing the nightly-only legacy override.
+- The warn-by-default `linker_messages` lint is covered by the manifest's
+  warnings-deny policy. The Rust 1.97.1 upgrade completed `just ci` on Linux,
+  macOS, and Windows without linker diagnostics, so no platform suppression is
+  justified.
+- `resolver.lockfile-path` is not configured. Local, CI, release-benchmark, and
+  historical-comparison worktrees are writable and use the committed root
+  `Cargo.lock`; an alternate path would split the lockfile and provenance source
+  without helping a read-only-source workflow.
+- The updated must-use behavior for `Result<_, Infallible>` and
+  `RepeatN::default` do not intersect production code in this repository.
 
 ## Contributor Workflow
 
@@ -60,6 +88,35 @@ with the behavior they support, avoid unrelated formatting churn, and cite
 relevant literature for numerical or algorithmic work. Automation and AI
 assistants must stop before version-control mutations and release operations; a
 human contributor performs and reviews commits, pushes, tags, and releases.
+
+### Validation Workflow
+
+Start with the smallest test selection that exercises the changed behavior. Use
+`cargo nextest run <test-name>` for a focused runnable test, `cargo test --doc
+<filter>` for a focused doctest, or `cargo nextest run --test <crate>` for one
+integration-test crate.
+
+For final validation of a non-core change, compose each affected surface once:
+
+- Documentation: `just markdown-ci`
+- Configuration and workflows: `just lint-config`
+- Python support tooling: `just python-ci`
+- Core Rust checks: `just rust-core-check`
+- Rust unit tests: `just test-unit`
+- Doctests: `just test-doc` and, when relevant, `just test-doc-exact`
+- Integration tests: `just test-integration`
+- Benchmark inputs or harnesses: `just test-bench-inputs` or `just bench-compile`
+- Examples: `just examples`
+
+Run `just ci` for core Rust, public behavior, or GitHub-equivalent validation.
+It composes leaf validators directly, runs unit and integration tests together
+once through the release-profile `test-rust-ci` bucket, and keeps doctests
+separate because nextest does not execute them. `just clippy` remains an
+optional all-target sweep outside this CI path.
+
+`la-stack` intentionally has no notebook validation bucket: the repository has
+no notebooks or supported Python binding surface. Add notebook tooling only
+alongside an actual maintained notebook interface rather than speculatively.
 
 ## Project References
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,9 +64,9 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "bumpalo"
@@ -76,9 +76,9 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytemuck"
-version = "1.25.1"
+version = "1.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6aedf8ae72766347502cf3cb4f41cf5e9cc37d28bee90f1fdaaae15f9cf9424"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
 dependencies = [
  "bytemuck_derive",
 ]
@@ -91,7 +91,7 @@ checksum = "f65693059b6b9c588b9f62fed1cedbf0a8b805631457ea162d68f0de186f3de5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -108,9 +108,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.66"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -151,18 +151,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.1"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+checksum = "301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "94a65403d1a1bd28f7dc68eb8506e8874808ee5eecb59298de588e2e1407a078"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -264,9 +264,9 @@ checksum = "e1d926b4d407d372f141f93bb444696142c29d32962ccbd3531117cf3aa0bfa9"
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "enum-as-inner"
@@ -277,7 +277,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -306,7 +306,7 @@ checksum = "3bf679796c0322556351f287a51b49e48f7c4986e727b5dd78c972d30e2e16cc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -365,9 +365,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "find-msvc-tools"
@@ -383,21 +383,21 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -654,9 +654,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libm"
@@ -672,9 +672,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "matrixmultiply"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
+checksum = "3f607c237553f086e7043417a51df26b2eb899d3caff94e6a67592ff992fedc7"
 dependencies = [
  "autocfg",
  "rawpointer",
@@ -926,9 +926,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
@@ -995,9 +995,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.46"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -1016,9 +1016,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha",
  "rand_core",
@@ -1095,9 +1095,9 @@ checksum = "03251193000f4bd3b042892be858ee50e8b3719f2b08e5833ac4353724632430"
 
 [[package]]
 name = "regex"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1107,9 +1107,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f388202e4b80542a0921078cc23b6333bcf1409c1e3f86404cae4766a6131db"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1155,9 +1155,9 @@ dependencies = [
 
 [[package]]
 name = "safe_arch"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f7caad094bd561859bcd467734a720c3c1f5d1f338995351fefe2190c45efed"
+checksum = "3a52ec151f024d703f9fd65abb7cbe81e7cdb39f18917a3a37e3014470dc7c59"
 dependencies = [
  "bytemuck",
 ]
@@ -1179,9 +1179,9 @@ checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -1189,29 +1189,29 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -1257,9 +1257,20 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.118"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1310,7 +1321,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1407,7 +1418,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
@@ -1432,9 +1443,9 @@ dependencies = [
 
 [[package]]
 name = "wide"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfdfe6a32973f2d1b268b8895845a8a96cac2f0191e72c27cc929036060dbf89"
+checksum = "be99e8317aa9f08e7d16e13033ca43faab59ab582b1d0feab7b385424c42f8b1"
 dependencies = [
  "bytemuck",
  "safe_arch",
@@ -1494,26 +1505,26 @@ checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.54"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.54"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/README.md
+++ b/README.md
@@ -571,11 +571,11 @@ cargo run --features exact --example exact_solve_3x3
 A short contributor workflow:
 
 Install Rust 1.97.1 through [rustup](https://rustup.rs/), Git, Python 3.14,
-[`uv` 0.12.0](https://docs.astral.sh/uv/), and `jq`. Then install the pinned
+[`uv` 0.12.1](https://docs.astral.sh/uv/), and `jq`. Then install the pinned
 `just` release from its locked dependency graph:
 
 ```bash
-cargo install --locked just --version 1.56.0
+cargo install --locked just --version 1.57.0
 just setup        # install/verify dev tools + sync Python deps
 just check        # lint/validate (non-mutating)
 just fix          # apply auto-fixes (mutating)

--- a/justfile
+++ b/justfile
@@ -11,17 +11,25 @@ cargo_home := env_var_or_default("CARGO_HOME", home_dir + "/.cargo")
 path_separator := if os_family() == "windows" { ";" } else { ":" }
 export PATH := cargo_home + "/bin" + path_separator + env_var("PATH")
 
+# Coverage (cargo-llvm-cov)
+#
+# Common cargo-llvm-cov arguments for all coverage runs.
+_coverage_base_args := '''--features exact \
+  --workspace --lib --tests \
+  --verbose'''
+cargo_llvm_cov_version := "0.8.7"
 cargo_machete_version := "0.9.2"
 cargo_nextest_version := "0.9.140"
-cargo_llvm_cov_version := "0.8.7"
+clippy_sarif_version := "0.8.0"
 dprint_version := "0.55.2"
 git_cliff_version := "2.13.1"
-just_version := "1.56.0"
-rumdl_version := "0.2.47"
+just_version := "1.57.0"
+rumdl_version := "0.2.48"
+sarif_fmt_version := "0.8.0"
 taplo_version := "0.10.0"
 typos_version := "1.48.0"
-uv_version := "0.12.0"
-zizmor_version := "1.28.0"
+uv_version := "0.12.1"
+zizmor_version := "1.29.0"
 
 # Internal helpers: ensure external tooling is installed
 _ensure-actionlint:
@@ -222,10 +230,6 @@ bench-latest: bench-vs-linalg-la-stack bench-exact
 bench-latest-vs-last baseline="last": bench-latest python-sync
     uv run --locked bench-compare {{ quote(baseline) }}
 
-# Run only la-stack vs_linalg measurements and render a non-exact performance report.
-bench-vs-linalg-latest-vs baseline="last": bench-vs-linalg-la-stack python-sync
-    uv run --locked bench-compare {{ quote(baseline) }} --suite vs_linalg --scope release-signal
-
 # Save a Criterion baseline. Defaults to all release-signal benchmark suites.
 bench-save-baseline tag suite="all":
     #!/usr/bin/env bash
@@ -267,6 +271,10 @@ bench-vs-linalg filter="":
 bench-vs-linalg-la-stack:
     cargo bench --locked --features bench --bench vs_linalg -- la_stack
 
+# Run only la-stack vs_linalg measurements and render a non-exact performance report.
+bench-vs-linalg-latest-vs baseline="last": bench-vs-linalg-la-stack python-sync
+    uv run --locked bench-compare {{ quote(baseline) }} --suite vs_linalg --scope release-signal
+
 # Quick iteration (reduced runtime, no Criterion HTML).
 bench-vs-linalg-quick filter="":
     #!/usr/bin/env bash
@@ -284,6 +292,10 @@ build:
 
 build-release:
     cargo build --release
+
+# Verify Cargo.toml and the committed Cargo.lock are synchronized.
+cargo-lock-check:
+    cargo metadata --locked --format-version 1 --no-deps > /dev/null
 
 # Changelog generation (git-cliff + post-processing + archiving)
 changelog: _ensure-git-cliff _ensure-rumdl python-sync
@@ -331,13 +343,10 @@ check: lint
 check-fast:
     cargo check
 
-# Verify Cargo.toml and the committed Cargo.lock are synchronized.
-cargo-lock-check:
-    cargo metadata --locked --format-version 1 --no-deps > /dev/null
-
-# CI simulation: comprehensive validation (matches CI expectations)
-# Runs: checks + all tests (Rust + Python) + examples + bench compile
-ci: check bench-compile test-all examples
+# CI simulation: flat GitHub-equivalent union of leaf validators.
+# Keep this dependency list explicit so each target class and validation surface
+# is composed once without re-entering broad check/test bundles.
+ci: action-lint zizmor markdown-check spell-check docs-version-check toml-parse-check toml-fmt-check toml-lint yaml-fmt-check yaml-lint citation-check validate-json justfile-fmt-check python-format-check python-lint python-typecheck test-python cargo-lock-check fmt-check clippy-core doc-check semgrep semgrep-test unused-deps shell-check test-rust-ci test-doc test-doc-exact bench-compile examples
     @echo "🎯 CI checks complete!"
 
 # Validate CITATION.cff against the Citation File Format schema.
@@ -350,23 +359,21 @@ clean:
     rm -rf target/llvm-cov
     rm -rf coverage
 
-# Code quality and formatting (lint levels are configured in Cargo.toml).
+# Optional broad Clippy sweep across tests, examples, and benches.
 clippy: clippy-all-targets
 
 clippy-all-targets:
     cargo clippy --workspace --all-targets
     cargo clippy --workspace --all-targets --all-features
 
+# Core library Clippy checks used by the orthogonal CI graph.
+clippy-core:
+    cargo clippy --workspace --lib
+    cargo clippy --workspace --lib --all-features
+
 # Clippy for the "exact" feature (catches feature-gated lint issues)
 clippy-exact:
     cargo clippy --features exact --all-targets
-
-# Coverage (cargo-llvm-cov)
-#
-# Common cargo-llvm-cov arguments for all coverage runs.
-_coverage_base_args := '''--features exact \
-  --workspace --lib --tests \
-  --verbose'''
 
 # Coverage analysis for local development (HTML output)
 coverage: _ensure-cargo-llvm-cov _ensure-cargo-nextest
@@ -429,6 +436,9 @@ fmt:
 fmt-check:
     cargo fmt --all -- --check
 
+github-actions-check: action-lint zizmor
+    @echo "✅ GitHub Actions checks complete!"
+
 help-workflows:
     @echo "Common Just workflows:"
     @echo "  just check             # Run lint/validators (non-mutating)"
@@ -473,11 +483,21 @@ help-workflows:
     @echo "  just test              # Lib + doc tests (fast)"
     @echo "  just test-all          # All tests (Rust + Python)"
     @echo "  just test-bench-inputs # Benchmark input smoke tests"
+    @echo "  just test-doc          # Default-feature doctests"
     @echo "  just test-exact        # Exact-feature tests and doctests"
     @echo "  just test-integration  # Integration tests"
     @echo "  just test-python       # Python tests only (pytest)"
+    @echo "  just test-rust-ci      # Release-profile unit + integration CI bucket"
+    @echo "  just test-unit         # Library unit tests"
     @echo ""
     @echo "Note: Some recipes require external tools. Run 'just setup-tools' (tooling) or 'just setup' (full env) first."
+
+# File validation
+json-check: validate-json
+
+# Keep the command-memory layer itself canonically formatted.
+justfile-fmt-check:
+    just --fmt --check
 
 # Lint groups (delaunay-style)
 lint: lint-code lint-docs lint-config
@@ -486,25 +506,7 @@ lint-code: rust-core-check python-check shell-check
 
 lint-config: json-check toml-ci yaml-ci github-actions-check justfile-fmt-check
 
-lint-docs: markdown-ci
-
-github-actions-check: action-lint zizmor
-    @echo "✅ GitHub Actions checks complete!"
-
-markdown-ci: markdown-check spell-check
-    @echo "✅ Markdown checks complete!"
-
-python-ci: python-check test-python
-    @echo "✅ Python checks complete!"
-
-rust-core-check: cargo-lock-check fmt-check clippy-all-targets doc-check semgrep semgrep-test unused-deps
-    @echo "✅ Rust core checks complete!"
-
-toml-ci: toml-check
-    @echo "✅ TOML checks complete!"
-
-yaml-ci: yaml-check citation-check
-    @echo "✅ YAML/CFF checks complete!"
+lint-docs: markdown-ci docs-version-check
 
 # Markdown
 markdown-check: _ensure-rumdl
@@ -542,6 +544,9 @@ markdown-check: _ensure-rumdl
     else
         echo "No markdown files found to check."
     fi
+
+markdown-ci: markdown-check spell-check
+    @echo "✅ Markdown checks complete!"
 
 markdown-fix: _ensure-rumdl
     #!/usr/bin/env bash
@@ -644,15 +649,20 @@ plot-vs-linalg-readme metric="lu_solve" stat="median" sample="new" log_y="true":
     uv run --locked criterion-dim-plot "${args[@]}"
 
 # Python tooling (uv)
-python-check: python-typecheck
-    uv run --locked ruff format --check scripts/
-    uv run --locked ruff check scripts/
+python-check: python-format-check python-lint python-typecheck
+
+python-ci: python-format-check python-lint python-typecheck test-python
+    @echo "✅ Python checks complete!"
 
 python-fix: python-sync
     uv run --locked ruff check scripts/ --fix
     uv run --locked ruff format scripts/
 
-python-lint: python-check
+python-format-check: python-sync
+    uv run --locked ruff format --check scripts/
+
+python-lint: python-sync
+    uv run --locked ruff check scripts/
 
 python-sync: _ensure-uv
     uv sync --locked --group dev
@@ -660,8 +670,11 @@ python-sync: _ensure-uv
 python-typecheck: python-sync
     uv run --locked ty check scripts/ --error all
 
+rust-core-check: cargo-lock-check fmt-check clippy-core doc-check semgrep semgrep-test unused-deps
+    @echo "✅ Rust core checks complete!"
+
 # Repository-owned Semgrep rules for project-specific diagnostics.
-semgrep: docs-version-check
+semgrep: _ensure-uv
     uv run --locked semgrep --metrics off --error --strict --timeout 30 --config semgrep.yaml .
 
 # Fixture tests for repository-owned Semgrep rules.
@@ -895,6 +908,10 @@ test: test-lib test-doc
 test-all: test-rust test-python
     @echo "✅ All tests passed"
 
+# Smoke-test deterministic inputs and configuration shared with benchmark suites.
+test-bench-inputs: _ensure-cargo-nextest
+    cargo nextest run --profile ci --features bench,exact --test vs_linalg_inputs --test exact_bench_config --verbose
+
 test-doc:
     cargo test --doc --verbose
 
@@ -905,34 +922,33 @@ test-doc-exact:
 test-exact: _ensure-cargo-nextest test-doc-exact
     cargo nextest run --profile ci --features exact --verbose
 
-# Smoke-test deterministic inputs and configuration shared with benchmark suites.
-test-bench-inputs: _ensure-cargo-nextest
-    cargo nextest run --profile ci --features bench,exact --test vs_linalg_inputs --test exact_bench_config --verbose
+test-integration: _ensure-cargo-nextest
+    cargo nextest run --profile ci --tests --verbose
 
 # Compile all integration-test targets without running them.
 test-integration-compile: _ensure-cargo-nextest
     cargo nextest run --all-features --tests --no-run
 
-test-integration: _ensure-cargo-nextest
-    cargo nextest run --profile ci --tests --verbose
-
 test-lib: _ensure-cargo-nextest
     cargo nextest run --profile ci --lib --verbose
-
-# CI Rust bucket: all runnable unit/integration targets in one nextest pass.
-test-rust-ci: _ensure-cargo-nextest
-    cargo nextest run --profile ci --all-features --lib --tests --verbose
-
-test-rust: test-rust-ci test-doc test-doc-exact
-    @echo "✅ Rust tests passed"
-
-test-unit: test-lib
 
 test-python: python-sync
     uv run --locked pytest -q
 
+test-rust: test-rust-ci test-doc test-doc-exact
+    @echo "✅ Rust tests passed"
+
+# CI Rust bucket: all runnable unit/integration targets in one nextest pass.
+test-rust-ci: _ensure-cargo-nextest
+    cargo nextest run --release --profile ci --all-features --lib --tests --verbose
+
+test-unit: test-lib
+
 # TOML
-toml-check: toml-fmt-check toml-lint
+toml-check: toml-parse-check toml-fmt-check toml-lint
+
+toml-ci: toml-check
+    @echo "✅ TOML checks complete!"
 
 toml-fix: toml-fmt
 
@@ -981,12 +997,25 @@ toml-lint: _ensure-taplo
         echo "No TOML files found to lint."
     fi
 
+# Validate TOML syntax independently with Python's standard-library parser.
+toml-parse-check: python-sync
+    #!/usr/bin/env bash
+    set -euo pipefail
+    files=()
+    while IFS= read -r -d '' file; do
+        if [ -f "$file" ]; then
+            files+=("$file")
+        fi
+    done < <(git ls-files -co --exclude-standard -z -- '*.toml')
+    if [ "${#files[@]}" -gt 0 ]; then
+        uv run --locked python -c 'import pathlib, sys, tomllib; [tomllib.loads(pathlib.Path(path).read_text(encoding="utf-8")) for path in sys.argv[1:]]' "${files[@]}"
+    else
+        echo "No TOML files found to parse."
+    fi
+
 # Check for unused direct Cargo dependencies.
 unused-deps: _ensure-cargo-machete
     cargo machete
-
-# File validation
-json-check: validate-json
 
 validate-json: _ensure-jq
     #!/usr/bin/env bash
@@ -1006,20 +1035,8 @@ validate-json: _ensure-jq
 # YAML
 yaml-check: yaml-fmt-check yaml-lint
 
-yaml-fmt-check: _ensure-dprint
-    #!/usr/bin/env bash
-    set -euo pipefail
-    files=()
-    while IFS= read -r -d '' file; do
-        if [ -f "$file" ]; then
-            files+=("$file")
-        fi
-    done < <(git ls-files -co --exclude-standard -z -- '*.yml' '*.yaml' 'CITATION.cff')
-    if [ "${#files[@]}" -gt 0 ]; then
-        printf '%s\0' "${files[@]}" | xargs -0 dprint check --incremental=false
-    else
-        echo "No YAML files found to check."
-    fi
+yaml-ci: yaml-check citation-check
+    @echo "✅ YAML/CFF checks complete!"
 
 yaml-fix: _ensure-dprint
     #!/usr/bin/env bash
@@ -1034,6 +1051,21 @@ yaml-fix: _ensure-dprint
         printf '%s\0' "${files[@]}" | xargs -0 dprint fmt --incremental=false
     else
         echo "No YAML files found to format."
+    fi
+
+yaml-fmt-check: _ensure-dprint
+    #!/usr/bin/env bash
+    set -euo pipefail
+    files=()
+    while IFS= read -r -d '' file; do
+        if [ -f "$file" ]; then
+            files+=("$file")
+        fi
+    done < <(git ls-files -co --exclude-standard -z -- '*.yml' '*.yaml' 'CITATION.cff')
+    if [ "${#files[@]}" -gt 0 ]; then
+        printf '%s\0' "${files[@]}" | xargs -0 dprint check --incremental=false
+    else
+        echo "No YAML files found to check."
     fi
 
 yaml-lint: _ensure-yamllint
@@ -1051,10 +1083,6 @@ yaml-lint: _ensure-yamllint
     else
         echo "No YAML files found to lint."
     fi
-
-# Keep the command-memory layer itself canonically formatted.
-justfile-fmt-check:
-    just --fmt --check
 
 # GitHub Actions security analysis
 zizmor: _ensure-zizmor

--- a/uv.lock
+++ b/uv.lock
@@ -1173,15 +1173,15 @@ wheels = [
 
 [[package]]
 name = "uvicorn"
-version = "0.52.0"
+version = "0.52.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "h11" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/05/c8/2d307868453a4bca6e64fa3581d122ae0748a0869c53f159339def179c7c/uvicorn-0.52.0.tar.gz", hash = "sha256:ca8876ad6c1983f394157c168b39d52f6dd56dabf5602fa0982751cffc2293ae", size = 97504, upload-time = "2026-07-29T08:45:34.065Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/18/ccce41535dee1be77735592bd19965f3972c82e07ee703d324709496b716/uvicorn-0.52.1.tar.gz", hash = "sha256:112ec661814189acbccd3f7b86460147cc065fc92c0821afa78918780e4354dd", size = 100571, upload-time = "2026-08-01T18:19:30.732Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/e6/b5c0630ace9757232aec07112be8146b812787db52141ff9d50674aa7634/uvicorn-0.52.0-py3-none-any.whl", hash = "sha256:3d887809810b89ed33501bcf0a9aba469b06ecd608158efce04bd6b48d8c9b08", size = 79058, upload-time = "2026-07-29T08:45:32.492Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/d5/68e6e9bca63c0badf67002890a46d3784c958de45b65e1275ec583ca1f06/uvicorn-0.52.1-py3-none-any.whl", hash = "sha256:e4403f9d93188cf9d1088e9f40e3acd12630e2df8675316704379a7fc20fff6a", size = 79859, upload-time = "2026-08-01T18:19:29.294Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Compose CI from orthogonal leaf validators with one release-profile nextest pass and separate doctests.
- Resolve workflow tooling through the justfile and shared setup action.
- Document focused validation, notebook scope, and Rust 1.97 tooling policy.
- Refresh development tools, security actions, Dependabot schedules, and lockfiles.

Closes #167
Closes #189

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added centralized setup and version validation for project development tools.
  - Added focused recipes for Rust, Python, benchmark, configuration, and documentation checks.
  - Added automated benchmark and integration test targets.

- **Documentation**
  - Updated contributor requirements and setup guidance for newer Rust, uv, and just versions.
  - Added guidance on warnings, linker diagnostics, lockfiles, and Rust compatibility.

- **Chores**
  - Updated security and analysis tooling to newer releases.
  - Improved CI scheduling and validation for more reliable checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->